### PR TITLE
add https support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ollama-rs = { git = "https://github.com/pepperoni21/ollama-rs" }
 let ollama = Ollama::default();
 
 // For custom values:
-let ollama = Ollama::new("localhost".to_string(), 11434);
+let ollama = Ollama::new("http://localhost".to_string(), 11434);
 ```
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,14 +20,14 @@ impl Ollama {
 
     /// Returns the http URI of the Ollama instance
     pub fn uri(&self) -> String {
-        format!("http://{}:{}", self.host, self.port)
+        format!("{}:{}", self.host, self.port)
     }
 }
 
 impl Default for Ollama {
     fn default() -> Self {
         Self {
-            host: "127.0.0.1".to_string(),
+            host: "http://127.0.0.1".to_string(),
             port: 11434,
             reqwest_client: reqwest::Client::new(),
         }


### PR DESCRIPTION
all i did was change the default to include http:// and edit the uri function to remove the http://
updated readme to reflect this

When using the default method nothing should change. but when specifying a url yourself you need to include the protocol (http/https)