### PR TITLE
format support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.vscode/settings.json
+shell.nix

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let ollama = Ollama::new("http://localhost".to_string(), 11434);
 let model = "llama2:latest".to_string();
 let prompt = "Why is the sky blue?".to_string();
 
-let res = ollama.generate(GenerationRequest::new(model, prompt)).await;
+let res = ollama.generate(GenerationRequest::new(model, prompt,None)).await;
 
 if let Ok(res) = res {
     println!("{}", res.response);
@@ -37,7 +37,7 @@ if let Ok(res) = res {
 let model = "llama2:latest".to_string();
 let prompt = "Why is the sky blue?".to_string();
 
-let mut stream = ollama.generate_stream(GenerationRequest::new(model, prompt)).await.unwrap();
+let mut stream = ollama.generate_stream(GenerationRequest::new(model, prompt,None)).await.unwrap();
 
 let mut stdout = tokio::io::stdout();
 // Requires tokio_stream

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ let ollama = Ollama::new("http://localhost".to_string(), 11434);
 let model = "llama2:latest".to_string();
 let prompt = "Why is the sky blue?".to_string();
 
-let res = ollama.generate(GenerationRequest::new(model, prompt,None)).await;
+let res = ollama.generate(GenerationRequest::new(model, prompt)).await;
 
 if let Ok(res) = res {
     println!("{}", res.response);
@@ -37,7 +37,7 @@ if let Ok(res) = res {
 let model = "llama2:latest".to_string();
 let prompt = "Why is the sky blue?".to_string();
 
-let mut stream = ollama.generate_stream(GenerationRequest::new(model, prompt,None)).await.unwrap();
+let mut stream = ollama.generate_stream(GenerationRequest::new(model, prompt)).await.unwrap();
 
 let mut stdout = tokio::io::stdout();
 // Requires tokio_stream

--- a/examples/chatbot.rs
+++ b/examples/chatbot.rs
@@ -1,6 +1,6 @@
 use ollama_rs::{
     generation::completion::{
-        request::GenerationRequest, GenerationContext, GenerationResponseStream,
+        request::{GenerationRequest, FormatEnum}, GenerationContext, GenerationResponseStream,
     },
     Ollama,
 };
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             break;
         }
 
-        let mut request = GenerationRequest::new("llama2:latest".into(), input.to_string());
+        let mut request = GenerationRequest::new("llama2:latest".into(), input.to_string(), None);
         if let Some(context) = context.clone() {
             request = request.context(context);
         }

--- a/examples/chatbot.rs
+++ b/examples/chatbot.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             break;
         }
 
-        let mut request = GenerationRequest::new("llama2:latest".into(), input.to_string(), None);
+        let mut request = GenerationRequest::new("llama2:latest".into(), input.to_string());
         if let Some(context) = context.clone() {
             request = request.context(context);
         }

--- a/src/generation/completion/request.rs
+++ b/src/generation/completion/request.rs
@@ -22,7 +22,7 @@ pub enum FormatEnum {
     Json,
 }
 impl GenerationRequest {
-    pub fn new(model_name: String, prompt: String, format: Option<FormatEnum>) -> Self {
+    pub fn new(model_name: String, prompt: String) -> Self {
         Self {
             model_name,
             prompt,
@@ -30,8 +30,8 @@ impl GenerationRequest {
             system: None,
             template: None,
             context: None,
-            //format value for now just json
-            format: format,
+            // The format to return a response in. Currently the only accepted value is `json`
+            format: None,
             // Stream value will be overwritten by Ollama::generate_stream() and Ollama::generate() methods
             stream: false,
         }

--- a/src/generation/completion/request.rs
+++ b/src/generation/completion/request.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::generation::options::GenerationOptions;
 
@@ -13,11 +13,16 @@ pub struct GenerationRequest {
     pub system: Option<String>,
     pub template: Option<String>,
     pub context: Option<GenerationContext>,
+    pub format: Option<FormatEnum>,
     pub(crate) stream: bool,
 }
-
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum FormatEnum {
+    Json,
+}
 impl GenerationRequest {
-    pub fn new(model_name: String, prompt: String) -> Self {
+    pub fn new(model_name: String, prompt: String, format: Option<FormatEnum>) -> Self {
         Self {
             model_name,
             prompt,
@@ -25,6 +30,8 @@ impl GenerationRequest {
             system: None,
             template: None,
             context: None,
+            //format value for now just json
+            format: format,
             // Stream value will be overwritten by Ollama::generate_stream() and Ollama::generate() methods
             stream: false,
         }

--- a/src/generation/options.rs
+++ b/src/generation/options.rs
@@ -1,7 +1,6 @@
 use serde::Serialize;
 
-#[derive(Debug, Clone, Serialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct GenerationOptions {
     pub(super) mirostat: Option<u8>,
     pub(super) mirostat_eta: Option<f32>,
@@ -20,8 +19,6 @@ pub struct GenerationOptions {
     pub(super) top_k: Option<u32>,
     pub(super) top_p: Option<f32>,
 }
-
-
 
 impl GenerationOptions {
     pub fn mirostat(mut self, mirostat: u8) -> Self {

--- a/tests/generation.rs
+++ b/tests/generation.rs
@@ -17,8 +17,7 @@ async fn test_generation_stream() {
     let mut res: GenerationResponseStream = ollama
         .generate_stream(GenerationRequest::new(
             "llama2:latest".to_string(),
-            PROMPT.into(),
-            None
+            PROMPT.into()
         ))
         .await
         .unwrap();
@@ -42,22 +41,7 @@ async fn test_generation() {
     let _ = ollama
         .generate(GenerationRequest::new(
             "llama2:latest".to_string(),
-            PROMPT.into(),
-            None
-        ))
-        .await
-        .unwrap();
-}
-#[tokio::test]
-async fn test_generation_json() {
-    let ollama = Ollama::default();
-
-    let _ = ollama
-        .generate(GenerationRequest::new(
-            "llama2:latest".to_string(),
-            PROMPT.into(),
-            Some(FormatEnum::Json)
-            
+            PROMPT.into()
         ))
         .await
         .unwrap();

--- a/tests/generation.rs
+++ b/tests/generation.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use ollama_rs::{
-    generation::completion::{request::GenerationRequest, GenerationResponseStream},
+    generation::completion::{request::{GenerationRequest, FormatEnum}, GenerationResponseStream},
     Ollama,
 };
 use tokio::io::AsyncWriteExt;
@@ -18,6 +18,7 @@ async fn test_generation_stream() {
         .generate_stream(GenerationRequest::new(
             "llama2:latest".to_string(),
             PROMPT.into(),
+            None
         ))
         .await
         .unwrap();
@@ -42,6 +43,21 @@ async fn test_generation() {
         .generate(GenerationRequest::new(
             "llama2:latest".to_string(),
             PROMPT.into(),
+            None
+        ))
+        .await
+        .unwrap();
+}
+#[tokio::test]
+async fn test_generation_json() {
+    let ollama = Ollama::default();
+
+    let _ = ollama
+        .generate_json(GenerationRequest::new(
+            "llama2:latest".to_string(),
+            PROMPT.into(),
+            Some(FormatEnum::Json)
+            
         ))
         .await
         .unwrap();

--- a/tests/generation.rs
+++ b/tests/generation.rs
@@ -53,7 +53,7 @@ async fn test_generation_json() {
     let ollama = Ollama::default();
 
     let _ = ollama
-        .generate_json(GenerationRequest::new(
+        .generate(GenerationRequest::new(
             "llama2:latest".to_string(),
             PROMPT.into(),
             Some(FormatEnum::Json)


### PR DESCRIPTION
with ollama 0.1.9  you can send if you want the output to be formatted.
for now it only supports JSON. but when left empty it generates as normal.

I added a parameter to GenerationRequest to specify if it needs to be formatted as json. when it is None it will leave out the parameter and generate as normal. I made it an enum as i seems like the format parameter might get more types and it would be easy to add new ones to it.