### PR TITLE
Add rustls feature without breaking default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,16 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.22" }
+reqwest = { version = "0.11.22", default-features = false }
 serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"
 tokio = { version = "1", features = ["full"], optional = true }
 tokio-stream = { version = "0.1.14", optional = true }
 
 [features]
+default = ["reqwest/default-tls"]
 stream = ["tokio-stream", "reqwest/stream", "tokio"]
+rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
My environment requires rustls so I added a feature for it. I tried to do it in the most non-breaking way I could think of so this could be included in a minor version change if desired.