### PR TITLE
Added the `Send` trait bound to all stream types

### DIFF
--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -11,7 +11,7 @@ use super::images::Image;
 #[cfg(feature = "stream")]
 /// A stream of `ChatMessageResponse` objects
 pub type ChatMessageResponseStream =
-    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<ChatMessageResponse, ()>>>>;
+    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<ChatMessageResponse, ()>> + Send>>;
 
 impl Ollama {
     #[cfg(feature = "stream")]

--- a/src/generation/completion/mod.rs
+++ b/src/generation/completion/mod.rs
@@ -9,7 +9,7 @@ pub mod request;
 #[cfg(feature = "stream")]
 /// A stream of `GenerationResponse` objects
 pub type GenerationResponseStream =
-    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<GenerationResponse, ()>>>>;
+    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = Result<GenerationResponse, ()>> + Send>>;
 
 impl Ollama {
     #[cfg(feature = "stream")]

--- a/src/models/create.rs
+++ b/src/models/create.rs
@@ -4,8 +4,9 @@ use crate::Ollama;
 
 /// A stream of `CreateModelStatus` objects
 #[cfg(feature = "stream")]
-pub type CreateModelStatusStream =
-    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = crate::error::Result<CreateModelStatus>>>>;
+pub type CreateModelStatusStream = std::pin::Pin<
+    Box<dyn tokio_stream::Stream<Item = crate::error::Result<CreateModelStatus>> + Send>,
+>;
 
 impl Ollama {
     #[cfg(feature = "stream")]

--- a/src/models/pull.rs
+++ b/src/models/pull.rs
@@ -4,8 +4,9 @@ use crate::Ollama;
 
 /// A stream of `PullModelStatus` objects.
 #[cfg(feature = "stream")]
-pub type PullModelStatusStream =
-    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = crate::error::Result<PullModelStatus>>>>;
+pub type PullModelStatusStream = std::pin::Pin<
+    Box<dyn tokio_stream::Stream<Item = crate::error::Result<PullModelStatus>> + Send>,
+>;
 
 impl Ollama {
     #[cfg(feature = "stream")]

--- a/src/models/push.rs
+++ b/src/models/push.rs
@@ -4,8 +4,9 @@ use crate::Ollama;
 
 /// A stream of `PushModelStatus` objects.
 #[cfg(feature = "stream")]
-pub type PushModelStatusStream =
-    std::pin::Pin<Box<dyn tokio_stream::Stream<Item = crate::error::Result<PushModelStatus>>>>;
+pub type PushModelStatusStream = std::pin::Pin<
+    Box<dyn tokio_stream::Stream<Item = crate::error::Result<PushModelStatus>> + Send>,
+>;
 
 impl Ollama {
     #[cfg(feature = "stream")]


### PR DESCRIPTION
The goal of this PR is to allow streams to work from `tokio::spawn`.

Consider the following example:
```rust
async fn stream_from_spawn() {
    tokio::spawn(async move {
        let ollama = Arc::new(Ollama::default());

        let mut stream = Ollama::default()
            .send_chat_messages_stream(ChatMessageRequest::new("mistral".to_string(), vec![]))
            .await
            .unwrap();

        let _next = stream.next().await;
    });
}
```
Since `spawn` requires its futures to be `Send`, the above code will not compile and produce the following error message:
```
error: future cannot be sent between threads safely
   --> src/main.rs:7:5
    |
7   |     tokio::spawn(async move {
    |     ^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `std::marker::Send` is not implemented for `dyn tokio_stream::Stream<Item = Result<ChatMessageResponse, ()>>`
note: future is not `Send` as this value is used across an await
```

The simplest solution is to add the `Send` trait bound to all stream types.
