### PR TITLE
Fix return type for generate function

### DIFF
--- a/src/generation/completion/mod.rs
+++ b/src/generation/completion/mod.rs
@@ -60,7 +60,10 @@ impl Ollama {
 
     /// Completion generation with a single response.
     /// Returns a single `GenerationResponse` object
-    pub async fn generate(&self, request: GenerationRequest) -> Result<GenerationResponse, String> {
+    pub async fn generate(
+        &self,
+        request: GenerationRequest,
+    ) -> crate::error::Result<GenerationResponse> {
         let mut request = request;
         request.stream = false;
 
@@ -75,7 +78,7 @@ impl Ollama {
             .map_err(|e| e.to_string())?;
 
         if !res.status().is_success() {
-            return Err(res.text().await.unwrap_or_else(|e| e.to_string()));
+            return Err(res.text().await.unwrap_or_else(|e| e.to_string()).into());
         }
 
         let res = res.bytes().await.map_err(|e| e.to_string())?;


### PR DESCRIPTION
As discussed here https://github.com/pepperoni21/ollama-rs/issues/15, this fixes the generate function. 

The relevant test passes, but I wasn't able to run all tests since I'm missing the `Modelfile.example` files. I want to create a setup function to create all necessary files (if not existent) first. What do you think?