### PR TITLE
Adds example on how to use completion options to README and /examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # Ollama-rs
+
 ### A simple and easy to use library for interacting with the Ollama API.
+
 It was made following the [Ollama API](https://github.com/jmorganca/ollama/blob/main/docs/api.md) documentation.
 
 ## Installation
+
 ### Add ollama-rs to your Cargo.toml
+
 ```toml
 [dependencies]
 ollama-rs = "0.1.6"
 ```
+
 ### Initialize Ollama
+
 ```rust
 // By default it will connect to localhost:11434
 let ollama = Ollama::default();
@@ -18,10 +24,13 @@ let ollama = Ollama::new("http://localhost".to_string(), 11434);
 ```
 
 ## Usage
+
 Feel free to check the [Chatbot example](examples/basic_chatbot.rs) that shows how to use the library to create a simple chatbot in less than 50 lines of code.
 
-*These examples use poor error handling for simplicity, but you should handle errors properly in your code.*
+_These examples use poor error handling for simplicity, but you should handle errors properly in your code._
+
 ### Completion generation
+
 ```rust
 let model = "llama2:latest".to_string();
 let prompt = "Why is the sky blue?".to_string();
@@ -32,9 +41,13 @@ if let Ok(res) = res {
     println!("{}", res.response);
 }
 ```
-**OUTPUTS:** *The sky appears blue because of a phenomenon called Rayleigh scattering...*
+
+**OUTPUTS:** _The sky appears blue because of a phenomenon called Rayleigh scattering..._
+
 ### Completion generation (streaming)
-*Requires the `stream` feature.*
+
+_Requires the `stream` feature._
+
 ```rust
 let model = "llama2:latest".to_string();
 let prompt = "Why is the sky blue?".to_string();
@@ -48,24 +61,58 @@ while let Some(res) = stream.next().await {
     stdout.flush().await.unwrap();
 }
 ```
+
 Same output as above but streamed.
+
+### Completion generation (passing options to the model)
+
+```rust
+let model = "llama2:latest".to_string();
+let prompt = "Why is the sky blue?".to_string();
+
+let options = GenerationOptions::default()
+    .temperature(0.2)
+    .repeat_penalty(1.5)
+    .top_k(25)
+    .top_p(0.25);
+
+let res = ollama.generate(GenerationRequest::new(model, prompt).options(options)).await;
+
+if let Ok(res) = res {
+    println!("{}", res.response);
+}
+```
+
+**OUTPUTS:** _1. Sun emits white sunlight: The sun consists primarily ..._
+
 ### List local models
+
 ```rust
 let res = ollama.list_local_models().await.unwrap();
 ```
-*Returns a vector of `Model` structs.*
+
+_Returns a vector of `Model` structs._
+
 ### Show model information
+
 ```rust
 let res = ollama.show_model_info("llama2:latest".to_string()).await.unwrap();
 ```
-*Returns a `ModelInfo` struct.*
+
+_Returns a `ModelInfo` struct._
+
 ### Create a model
+
 ```rust
 let res = ollama.create_model(CreateModelRequest::path("model".into(), "/tmp/Modelfile.example".into())).await.unwrap();
 ```
-*Returns a `CreateModelStatus` struct representing the final status of the model creation.*
+
+_Returns a `CreateModelStatus` struct representing the final status of the model creation._
+
 ### Create a model (streaming)
-*Requires the `stream` feature.*
+
+_Requires the `stream` feature._
+
 ```rust
 let mut res = ollama.create_model_stream(CreateModelRequest::path("model".into(), "/tmp/Modelfile.example".into())).await.unwrap();
 
@@ -74,18 +121,26 @@ while let Some(res) = res.next().await {
     // Handle the status
 }
 ```
-*Returns a `CreateModelStatusStream` that will stream every status update of the model creation.*
+
+_Returns a `CreateModelStatusStream` that will stream every status update of the model creation._
+
 ### Copy a model
+
 ```rust
 let _ = ollama.copy_model("mario".into(), "mario_copy".into()).await.unwrap();
 ```
+
 ### Delete a model
+
 ```rust
 let _ = ollama.delete_model("mario_copy".into()).await.unwrap();
 ```
+
 ### Generate embeddings
+
 ```rust
 let prompt = "Why is the sky blue?".to_string();
 let res = ollama.generate_embeddings("llama2:latest".to_string(), prompt, None).await.unwrap();
 ```
-*Returns a `GenerateEmbeddingsResponse` struct containing the embeddings (a vector of floats).*
+
+_Returns a `GenerateEmbeddingsResponse` struct containing the embeddings (a vector of floats)._

--- a/examples/completion_with_options.rs
+++ b/examples/completion_with_options.rs
@@ -1,0 +1,26 @@
+use ollama_rs::{
+    generation::{completion::request::GenerationRequest, options::GenerationOptions},
+    Ollama,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ollama = Ollama::default();
+    let model = "llama2:latest".to_string();
+    let prompt = "Why is the sky blue?".to_string();
+
+    let options = GenerationOptions::default()
+        .temperature(0.2)
+        .repeat_penalty(1.5)
+        .top_k(25)
+        .top_p(0.25);
+
+    let res = ollama
+        .generate(GenerationRequest::new(model, prompt).options(options))
+        .await;
+
+    if let Ok(res) = res {
+        println!("{}", res.response);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Added a snippet of using options (temperature, top_k, etc) when generating completions to README, and a working example to the /examples folder.

Hope this is useful.