### PR TITLE
feat: Store chat history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ tokio-stream = { version = "0.1.14", optional = true }
 default = ["reqwest/default-tls"]
 stream = ["tokio-stream", "reqwest/stream", "tokio"]
 rustls = ["reqwest/rustls-tls"]
+chat-history = []
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-ollama-rs = { path = ".", features = ["stream"] }
+ollama-rs = { path = ".", features = ["stream", "chat-history"] }
 base64 = "0.21.5"

--- a/examples/chat_with_history.rs
+++ b/examples/chat_with_history.rs
@@ -1,0 +1,43 @@
+use ollama_rs::{
+    generation::chat::{request::ChatMessageRequest, ChatMessage},
+    Ollama,
+};
+use tokio::io::{stdout, AsyncWriteExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut ollama = Ollama::new_default_with_history(30);
+
+    let mut stdout = stdout();
+
+    loop {
+        stdout.write_all(b"\n> ").await?;
+        stdout.flush().await?;
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+
+        let input = input.trim_end();
+        if input.eq_ignore_ascii_case("exit") {
+            break;
+        }
+
+        let user_message = ChatMessage::user(input.to_string());
+
+        let result = ollama
+            .send_chat_messages_with_history(
+                ChatMessageRequest::new("llama2:latest".to_string(), vec![user_message]),
+                "default".to_string(),
+            )
+            .await?;
+
+        let assistant_message = result.message.unwrap().content;
+        stdout.write_all(assistant_message.as_bytes()).await?;
+        stdout.flush().await?;
+    }
+
+    // Display whole history of messages
+    dbg!(&ollama.get_messages_history("default".to_string()));
+
+    Ok(())
+}

--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::Ollama;
@@ -91,6 +93,41 @@ impl Ollama {
 
         Ok(res)
     }
+
+    /// Chat message generation
+    /// Returns a `ChatMessageResponse` object
+    /// Manages the history of messages for the given `id`
+    pub async fn send_chat_message_with_history(
+        &mut self,
+        mut request: ChatMessageRequest,
+        id: String,
+    ) -> crate::error::Result<ChatMessageResponse> {
+        let mut backup = MessagesHistory::default();
+
+        let current_chat_messages = self
+            .messages_history
+            .as_mut()
+            .unwrap_or(&mut backup)
+            .messages_by_id
+            .entry(id.clone())
+            .or_default();
+
+        current_chat_messages.push(request.messages[0].clone());
+
+        request.messages = current_chat_messages.clone();
+
+        let result = self.send_chat_messages(request).await;
+
+        if let Ok(result) = result {
+            self.messages_history
+                .as_mut()
+                .unwrap_or(&mut backup)
+                .add_message(id, result.message.clone().unwrap());
+            return Ok(result);
+        }
+
+        result
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -164,7 +201,47 @@ impl ChatMessage {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default)]
+pub struct MessagesHistory {
+    pub(crate) messages_by_id: HashMap<String, Vec<ChatMessage>>,
+    pub(crate) messages_number_limit: u16,
+}
+
+impl MessagesHistory {
+    pub fn new(messages_number_limit: u16) -> Self {
+        Self {
+            messages_by_id: HashMap::new(),
+            messages_number_limit: messages_number_limit.max(2),
+        }
+    }
+
+    pub fn add_message(&mut self, entry_id: String, message: ChatMessage) {
+        let messages = self.messages_by_id.entry(entry_id).or_default();
+
+        // Replacing the oldest message if the limit is reached
+        // The oldest message is the first one, unless it's a system message
+        if messages.len() >= self.messages_number_limit as usize {
+            let index_to_remove = messages
+                .first()
+                .map(|m| if m.role == MessageRole::System { 1 } else { 0 })
+                .unwrap_or(0);
+
+            messages.remove(index_to_remove);
+        }
+
+        messages.push(message);
+    }
+
+    pub fn get_messages(&self, entry_id: &str) -> Option<&Vec<ChatMessage>> {
+        self.messages_by_id.get(entry_id)
+    }
+
+    pub fn clear_messages(&mut self, entry_id: &str) {
+        self.messages_by_id.remove(entry_id);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum MessageRole {
     #[serde(rename = "user")]
     User,

--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -214,14 +214,12 @@ impl ChatMessage {
     }
 }
 
-#[cfg(feature = "chat-history")]
 #[derive(Debug, Clone, Default)]
 pub struct MessagesHistory {
     pub(crate) messages_by_id: HashMap<String, Vec<ChatMessage>>,
     pub(crate) messages_number_limit: u16,
 }
 
-#[cfg(feature = "chat-history")]
 impl MessagesHistory {
     pub fn new(messages_number_limit: u16) -> Self {
         Self {

--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -93,11 +93,14 @@ impl Ollama {
 
         Ok(res)
     }
+}
 
+#[cfg(feature = "chat-history")]
+impl Ollama {
     /// Chat message generation
     /// Returns a `ChatMessageResponse` object
     /// Manages the history of messages for the given `id`
-    pub async fn send_chat_message_with_history(
+    pub async fn send_chat_messages_with_history(
         &mut self,
         mut request: ChatMessageRequest,
         id: String,
@@ -201,12 +204,14 @@ impl ChatMessage {
     }
 }
 
+#[cfg(feature = "chat-history")]
 #[derive(Debug, Clone, Default)]
 pub struct MessagesHistory {
     pub(crate) messages_by_id: HashMap<String, Vec<ChatMessage>>,
     pub(crate) messages_number_limit: u16,
 }
 
+#[cfg(feature = "chat-history")]
 impl MessagesHistory {
     pub fn new(messages_number_limit: u16) -> Self {
         Self {
@@ -229,7 +234,11 @@ impl MessagesHistory {
             messages.remove(index_to_remove);
         }
 
-        messages.push(message);
+        if message.role == MessageRole::System {
+            messages.insert(0, message);
+        } else {
+            messages.push(message);
+        }
     }
 
     pub fn get_messages(&self, entry_id: &str) -> Option<&Vec<ChatMessage>> {

--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -118,7 +118,7 @@ impl Ollama {
 
         if let Ok(result) = result {
             // Message we sent to AI
-            if let Some(message) = request.messages.first() {
+            if let Some(message) = request.messages.last() {
                 self.store_chat_message_by_id(id.clone(), message.clone());
             }
             // AI's response store in the history

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use generation::chat::{ChatMessage, MessagesHistory};
+
 pub mod error;
 pub mod generation;
 pub mod models;
@@ -7,6 +9,7 @@ pub struct Ollama {
     pub(crate) host: String,
     pub(crate) port: u16,
     pub(crate) reqwest_client: reqwest::Client,
+    pub(crate) messages_history: Option<MessagesHistory>,
 }
 
 impl Ollama {
@@ -18,9 +21,32 @@ impl Ollama {
         }
     }
 
+    pub fn new_default_with_history(messages_number_limit: u16) -> Self {
+        Self {
+            messages_history: Some(MessagesHistory::new(messages_number_limit)),
+            ..Default::default()
+        }
+    }
+
+    pub fn new_with_history(host: String, port: u16, messages_number_limit: u16) -> Self {
+        Self {
+            host,
+            port,
+            messages_history: Some(MessagesHistory::new(messages_number_limit)),
+            ..Default::default()
+        }
+    }
+
     /// Returns the http URI of the Ollama instance
     pub fn uri(&self) -> String {
         format!("{}:{}", self.host, self.port)
+    }
+
+    /// Add message to a history
+    pub fn add_assistant_response(&mut self, entry_id: String, message: String) {
+        if let Some(messages_history) = self.messages_history.as_mut() {
+            messages_history.add_message(entry_id, ChatMessage::assistant(message));
+        }
     }
 }
 
@@ -31,6 +57,7 @@ impl Default for Ollama {
             host: "http://127.0.0.1".to_string(),
             port: 11434,
             reqwest_client: reqwest::Client::new(),
+            messages_history: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub struct Ollama {
     pub(crate) host: String,
     pub(crate) port: u16,
     pub(crate) reqwest_client: reqwest::Client,
+    #[cfg(feature = "chat-history")]
     pub(crate) messages_history: Option<MessagesHistory>,
 }
 
@@ -21,13 +22,24 @@ impl Ollama {
         }
     }
 
+    /// Returns the http URI of the Ollama instance
+    pub fn uri(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+
+}
+
+#[cfg(feature = "chat-history")]
+impl Ollama {
+    /// Create default instance with chat history
     pub fn new_default_with_history(messages_number_limit: u16) -> Self {
         Self {
             messages_history: Some(MessagesHistory::new(messages_number_limit)),
             ..Default::default()
         }
     }
-
+    
+    /// Create new instance with chat history 
     pub fn new_with_history(host: String, port: u16, messages_number_limit: u16) -> Self {
         Self {
             host,
@@ -36,16 +48,35 @@ impl Ollama {
             ..Default::default()
         }
     }
-
-    /// Returns the http URI of the Ollama instance
-    pub fn uri(&self) -> String {
-        format!("{}:{}", self.host, self.port)
-    }
-
-    /// Add message to a history
+    
+    /// Add AI's message to a history
     pub fn add_assistant_response(&mut self, entry_id: String, message: String) {
         if let Some(messages_history) = self.messages_history.as_mut() {
             messages_history.add_message(entry_id, ChatMessage::assistant(message));
+        }
+    }
+
+    /// Add user's message to a history
+    pub fn add_user_response(&mut self, entry_id: String, message: String) {
+        if let Some(messages_history) = self.messages_history.as_mut() {
+            messages_history.add_message(entry_id, ChatMessage::user(message));
+        }
+    }
+
+    /// Set system prompt for chat history
+    pub fn set_system_response(&mut self, entry_id: String, message: String) {
+        if let Some(messages_history) = self.messages_history.as_mut() {
+            messages_history.add_message(entry_id, ChatMessage::system(message));
+        }
+    }
+
+    /// For tests purpose
+    /// Getting list of messages in a history
+    pub fn get_messages_history(&mut self, entry_id: String) -> Option<&Vec<ChatMessage>> {
+        if let Some(messages_history) = self.messages_history.as_mut() {
+            messages_history.messages_by_id.get(&entry_id)
+        } else {
+            None
         }
     }
 }
@@ -57,6 +88,7 @@ impl Default for Ollama {
             host: "http://127.0.0.1".to_string(),
             port: 11434,
             reqwest_client: reqwest::Client::new(),
+            #[cfg(feature = "chat-history")]
             messages_history: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "chat-history")]
 use generation::chat::{ChatMessage, MessagesHistory};
 
 pub mod error;
@@ -26,7 +27,6 @@ impl Ollama {
     pub fn uri(&self) -> String {
         format!("{}:{}", self.host, self.port)
     }
-
 }
 
 #[cfg(feature = "chat-history")]
@@ -38,8 +38,8 @@ impl Ollama {
             ..Default::default()
         }
     }
-    
-    /// Create new instance with chat history 
+
+    /// Create new instance with chat history
     pub fn new_with_history(host: String, port: u16, messages_number_limit: u16) -> Self {
         Self {
             host,
@@ -48,7 +48,7 @@ impl Ollama {
             ..Default::default()
         }
     }
-    
+
     /// Add AI's message to a history
     pub fn add_assistant_response(&mut self, entry_id: String, message: String) {
         if let Some(messages_history) = self.messages_history.as_mut() {

--- a/tests/chat_history_management.rs
+++ b/tests/chat_history_management.rs
@@ -1,4 +1,4 @@
-use ollama_rs::{generation::chat::ChatMessage, Ollama};
+use ollama_rs::Ollama;
 
 #[test]
 fn test_chat_history_saved_as_should() {

--- a/tests/chat_history_management.rs
+++ b/tests/chat_history_management.rs
@@ -1,0 +1,22 @@
+use ollama_rs::{generation::chat::ChatMessage, Ollama};
+
+#[test]
+fn test_chat_history_saved_as_should() {
+    let mut ollama = Ollama::new_default_with_history(30);
+    let chat_id = "default".to_string();
+
+    ollama.add_user_response(chat_id.clone(), "Hello".to_string());
+    ollama.add_assistant_response(chat_id.clone(), "Hi".to_string());
+
+    ollama.add_user_response(chat_id.clone(), "Tell me 'hi' again".to_string());
+    ollama.add_assistant_response(chat_id.clone(), "Hi again".to_string());
+
+    assert_eq!(
+        ollama.get_messages_history(chat_id.clone()).unwrap().len(),
+        4
+    );
+
+    let last = ollama.get_messages_history(chat_id).unwrap().last();
+    assert!(last.is_some());
+    assert_eq!(last.unwrap().content, "Hi again".to_string());
+}

--- a/tests/send_chat_messages.rs
+++ b/tests/send_chat_messages.rs
@@ -58,6 +58,7 @@ async fn test_send_chat_messages() {
 async fn test_send_chat_messages_with_history() {
     let mut ollama = Ollama::new_default_with_history(30);
     let id = "default".to_string();
+    let second_message = vec![ChatMessage::user("Second message".to_string())];
 
     let messages = vec![ChatMessage::user(PROMPT.to_string())];
     let res = ollama
@@ -75,7 +76,7 @@ async fn test_send_chat_messages_with_history() {
 
     let res = ollama
         .send_chat_messages_with_history(
-            ChatMessageRequest::new("llama2:latest".to_string(), messages),
+            ChatMessageRequest::new("llama2:latest".to_string(), second_message.clone()),
             id.clone(),
         )
         .await
@@ -85,6 +86,14 @@ async fn test_send_chat_messages_with_history() {
     assert!(res.done);
     // Should now have 2 user messages as well as AI's responses
     assert_eq!(ollama.get_messages_history(id.clone()).unwrap().len(), 4);
+
+    let second_user_message_in_history = ollama.get_messages_history(id.clone()).unwrap().get(2);
+
+    assert!(second_user_message_in_history.is_some());
+    assert_eq!(
+        second_user_message_in_history.unwrap().content,
+        "Second message".to_string()
+    );
 }
 
 #[tokio::test]

--- a/tests/send_chat_messages.rs
+++ b/tests/send_chat_messages.rs
@@ -54,6 +54,42 @@ async fn test_send_chat_messages() {
     assert!(res.done);
 }
 
+#[tokio::test]
+async fn test_send_chat_messages_with_history() {
+    let mut ollama = Ollama::new_default_with_history(30);
+    let id = "default".to_string();
+
+    let messages = vec![ChatMessage::user(PROMPT.to_string())];
+    let res = ollama
+        .send_chat_messages_with_history(ChatMessageRequest::new(
+            "llama2:latest".to_string(),
+            messages.clone(),
+        ), id.clone())
+        .await
+        .unwrap();
+
+    dbg!(&res);
+    assert!(res.done);
+    // Should have user's message as well as AI's response
+    assert_eq!(ollama.get_messages_history(id.clone()).unwrap().len(), 2);
+
+    let res = ollama
+        .send_chat_messages_with_history(
+            ChatMessageRequest::new(
+                "llama2:latest".to_string(),
+                messages,
+            ),
+            id.clone()
+        )
+        .await
+        .unwrap();
+
+    dbg!(&res);
+    assert!(res.done);
+    // Should now have 2 user messages as well as AI's responses
+    assert_eq!(ollama.get_messages_history(id.clone()).unwrap().len(), 4);
+}
+
 const IMAGE_URL: &str = "https://images.pexels.com/photos/1054655/pexels-photo-1054655.jpeg";
 
 #[tokio::test]


### PR DESCRIPTION
Adding feature to store chat history on lib's side.
User send only one message and lib pre-fill all history with stored messages.

Example usage (`discord bot`) : 
```rust
lazy_static! {
    static ref OLLAMA: Mutex<Ollama> = Mutex::new(Ollama::new_default_with_history(30));
}

// ...
let mut ollama = OLLAMA.lock().await;

ollama.send_chat_messages_with_history(
            ChatMessageRequest::new(
                env::var("OLLAMA_MODEL").unwrap_or("llama2".to_string()),
                vec![ChatMessage::user(message)],
            ),
            user_id, // Or any id you provide for history_id
        )
        .await
```

Hope you find this feature useful.
Open for improvements, thanks.