### PR TITLE
Re-add Send for GenerationResponseStream

### DIFF
--- a/src/generation/completion/mod.rs
+++ b/src/generation/completion/mod.rs
@@ -9,7 +9,7 @@ pub mod request;
 #[cfg(feature = "stream")]
 /// A stream of `GenerationResponse` objects
 pub type GenerationResponseStream = std::pin::Pin<
-    Box<dyn tokio_stream::Stream<Item = crate::error::Result<GenerationResponseStreamChunk>>>,
+    Box<dyn tokio_stream::Stream<Item = crate::error::Result<GenerationResponseStreamChunk>> + Send>,
 >;
 pub type GenerationResponseStreamChunk = Vec<GenerationResponse>;
 

--- a/src/generation/completion/mod.rs
+++ b/src/generation/completion/mod.rs
@@ -9,7 +9,9 @@ pub mod request;
 #[cfg(feature = "stream")]
 /// A stream of `GenerationResponse` objects
 pub type GenerationResponseStream = std::pin::Pin<
-    Box<dyn tokio_stream::Stream<Item = crate::error::Result<GenerationResponseStreamChunk>> + Send>,
+    Box<
+        dyn tokio_stream::Stream<Item = crate::error::Result<GenerationResponseStreamChunk>> + Send,
+    >,
 >;
 pub type GenerationResponseStreamChunk = Vec<GenerationResponse>;
 


### PR DESCRIPTION
Re-add Send to GenerationResponseStream, which was fixed in https://github.com/pepperoni21/ollama-rs/pull/14 but was undone in https://github.com/pepperoni21/ollama-rs/pull/13/files#diff-7cbb70dd16d7a45e6e2ff69fa40768ff25c2e6a55aa17810ac365c566dbbe645R11-R14