### PR TITLE
Add Serialize Support for Further Stucts

### DIFF
--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -154,7 +154,7 @@ impl Ollama {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatMessageResponse {
     /// The name of the model used for the completion.
     pub model: String,
@@ -168,7 +168,7 @@ pub struct ChatMessageResponse {
     pub final_data: Option<ChatMessageFinalResponseData>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatMessageFinalResponseData {
     /// Time spent generating the response
     pub total_duration: u64,

--- a/src/generation/chat/request.rs
+++ b/src/generation/chat/request.rs
@@ -1,11 +1,11 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::generation::{options::GenerationOptions, parameters::FormatType};
 
 use super::ChatMessage;
 
 /// A chat message request to Ollama.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessageRequest {
     #[serde(rename = "model")]
     pub model_name: String,

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,10 +6,10 @@ pub mod pull;
 pub mod push;
 pub mod show_info;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A local model pulled from Ollama.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalModel {
     pub name: String,
     pub modified_at: String,
@@ -17,7 +17,7 @@ pub struct LocalModel {
 }
 
 /// A model's info.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {
     pub license: String,
     pub modelfile: String,


### PR DESCRIPTION
Adds `serde` Serialization to remaining structs. Handy for proxying requests through Tauri's RPC.