### PR TITLE
fix: Adds back custom `Result` type for generate function

### DIFF
--- a/src/generation/completion/mod.rs
+++ b/src/generation/completion/mod.rs
@@ -61,7 +61,10 @@ impl Ollama {
 
     /// Completion generation with a single response.
     /// Returns a single `GenerationResponse` object
-    pub async fn generate(&self, request: GenerationRequest) -> Result<GenerationResponse, String> {
+    pub async fn generate(
+        &self,
+        request: GenerationRequest,
+    ) -> crate::error::Result<GenerationResponse> {
         let mut request = request;
         request.stream = false;
 
@@ -76,7 +79,7 @@ impl Ollama {
             .map_err(|e| e.to_string())?;
 
         if !res.status().is_success() {
-            return Err(res.text().await.unwrap_or_else(|e| e.to_string()));
+            return Err(res.text().await.unwrap_or_else(|e| e.to_string()).into());
         }
 
         let res = res.bytes().await.map_err(|e| e.to_string())?;


### PR DESCRIPTION
This brings back: https://github.com/pepperoni21/ollama-rs/pull/16 which seems to have gotten squashed / left behind due to: https://github.com/pepperoni21/ollama-rs/commit/37b6e614ba67e9843e49c03064739309b9ad8939

Maybe there are some tests that could be added to assert the right types are being returned so client consumers don't have disruption using this library? I'm using it with `anyhow` and I had to apply this patch to get `generate` to be accepted easily as an `anyhow::Result`