### PR TITLE
update: update README streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ let mut stream = ollama.generate_stream(GenerationRequest::new(model, prompt)).a
 
 let mut stdout = tokio::io::stdout();
 while let Some(res) = stream.next().await {
-    let res = res.unwrap();
-    stdout.write(res.response.as_bytes()).await.unwrap();
-    stdout.flush().await.unwrap();
+    let responses = res.unwrap();
+    for resp in responses {
+        stdout.write(resp.response.as_bytes()).await.unwrap();
+        stdout.flush().await.unwrap();
+    }
 }
 ```
 


### PR DESCRIPTION
There is a small bug in the generate streaming example, specifically the stream actually returns `Option<Result<Vec<GenerationResponse>>>`, which the example doesnt account for. 

This PR updates the `README` by adding the iteration loop over the returned `GenerationResponseStreamChunk`(s).