### PR TITLE
make `ModelInfo` fields empty by default

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -16,11 +16,15 @@ pub struct LocalModel {
     pub size: u64,
 }
 
-/// A model's info.
+/// A model's info. Some fields may be empty if the model does not have them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {
+    #[serde(default = "String::new")]
     pub license: String,
+    #[serde(default = "String::new")]
     pub modelfile: String,
+    #[serde(default = "String::new")]
     pub parameters: String,
+    #[serde(default = "String::new")]
     pub template: String,
 }


### PR DESCRIPTION
Not all models have all of `ModelInfo`'s fields, so sometimes there will be errors like this one:

An error occurred with ollama-rs: missing field `license` at line 1 column 1125

* Make `ModelInfo` fields be empty by default
* Mention that in the documentation