### PR TITLE
Replace host string and port with `Url`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -486,6 +486,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "url",
 ]
 
 [[package]]
@@ -563,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
@@ -634,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
  "base64",
  "bytes",
@@ -1089,9 +1090,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.12.3", default-features = false }
-serde = { version = "1.0.190", features = ["derive"] }
-serde_json = "1.0.116"
+reqwest = { version = "0.12.4", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["full"], optional = true }
 tokio-stream = { version = "0.1.15", optional = true }
+url = "2"
 
 [features]
 default = ["reqwest/default-tls"]

--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -29,7 +29,7 @@ impl Ollama {
         let mut request = request;
         request.stream = true;
 
-        let url = format!("{}/api/chat", self.url_str());
+        let url = format!("{}api/chat", self.url_str());
         let serialized = serde_json::to_string(&request)
             .map_err(|e| e.to_string())
             .unwrap();
@@ -74,7 +74,7 @@ impl Ollama {
         let mut request = request;
         request.stream = false;
 
-        let url = format!("{}/api/chat", self.url_str());
+        let url = format!("{}api/chat", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client

--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -29,13 +29,13 @@ impl Ollama {
         let mut request = request;
         request.stream = true;
 
-        let uri = format!("{}/api/chat", self.uri());
+        let url = format!("{}/api/chat", self.url_str());
         let serialized = serde_json::to_string(&request)
             .map_err(|e| e.to_string())
             .unwrap();
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await
@@ -74,11 +74,11 @@ impl Ollama {
         let mut request = request;
         request.stream = false;
 
-        let uri = format!("{}/api/chat", self.uri());
+        let url = format!("{}/api/chat", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await

--- a/src/generation/completion/mod.rs
+++ b/src/generation/completion/mod.rs
@@ -30,7 +30,7 @@ impl Ollama {
         let mut request = request;
         request.stream = true;
 
-        let url = format!("{}/api/generate", self.url_str());
+        let url = format!("{}api/generate", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
@@ -68,7 +68,7 @@ impl Ollama {
         let mut request = request;
         request.stream = false;
 
-        let url = format!("{}/api/generate", self.url_str());
+        let url = format!("{}api/generate", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client

--- a/src/generation/completion/mod.rs
+++ b/src/generation/completion/mod.rs
@@ -30,11 +30,11 @@ impl Ollama {
         let mut request = request;
         request.stream = true;
 
-        let uri = format!("{}/api/generate", self.uri());
+        let url = format!("{}/api/generate", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await
@@ -68,11 +68,11 @@ impl Ollama {
         let mut request = request;
         request.stream = false;
 
-        let uri = format!("{}/api/generate", self.uri());
+        let url = format!("{}/api/generate", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await

--- a/src/generation/embeddings.rs
+++ b/src/generation/embeddings.rs
@@ -20,11 +20,11 @@ impl Ollama {
             options,
         };
 
-        let uri = format!("{}/api/embeddings", self.uri());
+        let url = format!("{}/api/embeddings", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await

--- a/src/generation/embeddings.rs
+++ b/src/generation/embeddings.rs
@@ -20,7 +20,7 @@ impl Ollama {
             options,
         };
 
-        let url = format!("{}/api/embeddings", self.url_str());
+        let url = format!("{}api/embeddings", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client

--- a/src/history.rs
+++ b/src/history.rs
@@ -84,7 +84,7 @@ impl Ollama {
     }
 
     #[inline]
-    pub fn new_with_history_try_new(
+    pub fn try_new_with_history(
         url: impl crate::IntoUrl,
         messages_number_limit: u16,
     ) -> Result<Self, url::ParseError> {

--- a/src/history.rs
+++ b/src/history.rs
@@ -59,10 +59,25 @@ impl Ollama {
     }
 
     /// Create new instance with chat history
-    pub fn new_with_history(host: String, port: u16, messages_number_limit: u16) -> Self {
+    ///
+    /// # Panics
+    ///
+    /// Panics if the host is not a valid URL or if the URL cannot have a port.
+    pub fn new_with_history(
+        host: impl Into<url::Url>,
+        port: u16,
+        messages_number_limit: u16,
+    ) -> Self {
+        let mut url = host.into();
+        url.set_port(Some(port)).unwrap();
+        Self::new_with_history_from_url(url, messages_number_limit)
+    }
+
+    /// Create new instance with chat history from a [`url::Url`].
+    #[inline]
+    pub fn new_with_history_from_url(url: url::Url, messages_number_limit: u16) -> Self {
         Self {
-            host,
-            port,
+            url,
             messages_history: Some(MessagesHistory::new(messages_number_limit)),
             ..Default::default()
         }

--- a/src/history.rs
+++ b/src/history.rs
@@ -83,6 +83,18 @@ impl Ollama {
         }
     }
 
+    #[inline]
+    pub fn new_with_history_try_new(
+        url: impl crate::IntoUrl,
+        messages_number_limit: u16,
+    ) -> Result<Self, url::ParseError> {
+        Ok(Self {
+            url: url.into_url()?,
+            messages_history: Some(MessagesHistory::new(messages_number_limit)),
+            ..Default::default()
+        })
+    }
+
     /// Add AI's message to a history
     pub fn add_assistant_response(&mut self, entry_id: String, message: String) {
         if let Some(messages_history) = self.messages_history.as_mut() {

--- a/src/history.rs
+++ b/src/history.rs
@@ -64,11 +64,11 @@ impl Ollama {
     ///
     /// Panics if the host is not a valid URL or if the URL cannot have a port.
     pub fn new_with_history(
-        host: impl Into<url::Url>,
+        host: impl crate::IntoUrl,
         port: u16,
         messages_number_limit: u16,
     ) -> Self {
-        let mut url = host.into();
+        let mut url = host.into_url().unwrap();
         url.set_port(Some(port)).unwrap();
         Self::new_with_history_from_url(url, messages_number_limit)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,12 @@ impl Ollama {
         Self::from_url(url)
     }
 
+    /// Tries to create new instance by converting `url` into [`Url`].
+    #[inline]
+    pub fn try_new(url: impl IntoUrl) -> Result<Self, url::ParseError> {
+        Ok(Self::from_url(url.into_url()?))
+    }
+
     /// Create new instance from a [`Url`].
     #[inline]
     pub fn from_url(url: Url) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,25 +6,69 @@ pub mod models;
 
 #[derive(Debug, Clone)]
 pub struct Ollama {
-    pub(crate) host: String,
-    pub(crate) port: u16,
+    pub(crate) url: url::Url,
     pub(crate) reqwest_client: reqwest::Client,
     #[cfg(feature = "chat-history")]
     pub(crate) messages_history: Option<history::MessagesHistory>,
 }
 
 impl Ollama {
-    pub fn new(host: String, port: u16) -> Self {
+    /// # Panics
+    ///
+    /// Panics if the host is not a valid URL or if the URL cannot have a port.
+    pub fn new(host: impl Into<url::Url>, port: u16) -> Self {
+        let mut url = host.into();
+        url.set_port(Some(port)).unwrap();
+
+        Self::from_url(url)
+    }
+
+    /// Create new instance from a [`url::Url`].
+    #[inline]
+    pub fn from_url(url: url::Url) -> Self {
         Self {
-            host,
-            port,
+            url,
             ..Default::default()
         }
     }
 
     /// Returns the http URI of the Ollama instance
+    ///
+    /// # Panics
+    ///
+    /// Panics if the URL does not have a host.
+    #[inline]
     pub fn uri(&self) -> String {
-        format!("{}:{}", self.host, self.port)
+        self.url.host().unwrap().to_string()
+    }
+
+    /// Returns the URL of the Ollama instance as a [`url::Url`].
+    pub fn url(&self) -> &url::Url {
+        &self.url
+    }
+
+    /// Returns the URL of the Ollama instance as a [str].
+    ///
+    /// Syntax in pseudo-BNF:
+    ///
+    /// ```bnf
+    ///   url = scheme ":" [ hierarchical | non-hierarchical ] [ "?" query ]? [ "#" fragment ]?
+    ///   non-hierarchical = non-hierarchical-path
+    ///   non-hierarchical-path = /* Does not start with "/" */
+    ///   hierarchical = authority? hierarchical-path
+    ///   authority = "//" userinfo? host [ ":" port ]?
+    ///   userinfo = username [ ":" password ]? "@"
+    ///   hierarchical-path = [ "/" path-segment ]+
+    /// ```
+    #[inline]
+    pub fn url_str(&self) -> &str {
+        self.url.as_str()
+    }
+}
+
+impl From<url::Url> for Ollama {
+    fn from(url: url::Url) -> Self {
+        Self::from_url(url)
     }
 }
 
@@ -32,8 +76,7 @@ impl Default for Ollama {
     /// Returns a default Ollama instance with the host set to `http://127.0.0.1:11434`.
     fn default() -> Self {
         Self {
-            host: "http://127.0.0.1".to_string(),
-            port: 11434,
+            url: url::Url::parse("http://127.0.0.1:11434").unwrap(),
             reqwest_client: reqwest::Client::new(),
             #[cfg(feature = "chat-history")]
             messages_history: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl<'a> IntoUrlSealed for &'a String {
     }
 }
 
-impl<'a> IntoUrlSealed for String {
+impl IntoUrlSealed for String {
     fn into_url(self) -> Result<Url, url::ParseError> {
         (&*self).into_url()
     }

--- a/src/models/copy.rs
+++ b/src/models/copy.rs
@@ -14,11 +14,11 @@ impl Ollama {
             destination,
         };
 
-        let uri = format!("{}/api/copy", self.uri());
+        let url = format!("{}/api/copy", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await

--- a/src/models/copy.rs
+++ b/src/models/copy.rs
@@ -14,7 +14,7 @@ impl Ollama {
             destination,
         };
 
-        let url = format!("{}/api/copy", self.url_str());
+        let url = format!("{}api/copy", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client

--- a/src/models/create.rs
+++ b/src/models/create.rs
@@ -21,11 +21,11 @@ impl Ollama {
 
         request.stream = true;
 
-        let uri = format!("{}/api/create", self.uri());
+        let url = format!("{}/api/create", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await
@@ -63,11 +63,11 @@ impl Ollama {
         &self,
         request: CreateModelRequest,
     ) -> crate::error::Result<CreateModelStatus> {
-        let uri = format!("{}/api/create", self.uri());
+        let url = format!("{}/api/create", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await

--- a/src/models/create.rs
+++ b/src/models/create.rs
@@ -21,7 +21,7 @@ impl Ollama {
 
         request.stream = true;
 
-        let url = format!("{}/api/create", self.url_str());
+        let url = format!("{}api/create", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
@@ -63,7 +63,7 @@ impl Ollama {
         &self,
         request: CreateModelRequest,
     ) -> crate::error::Result<CreateModelStatus> {
-        let url = format!("{}/api/create", self.url_str());
+        let url = format!("{}api/create", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client

--- a/src/models/delete.rs
+++ b/src/models/delete.rs
@@ -7,7 +7,7 @@ impl Ollama {
     pub async fn delete_model(&self, model_name: String) -> crate::error::Result<()> {
         let request = DeleteModelRequest { model_name };
 
-        let url = format!("{}/api/delete", self.url_str());
+        let url = format!("{}api/delete", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client

--- a/src/models/delete.rs
+++ b/src/models/delete.rs
@@ -7,11 +7,11 @@ impl Ollama {
     pub async fn delete_model(&self, model_name: String) -> crate::error::Result<()> {
         let request = DeleteModelRequest { model_name };
 
-        let uri = format!("{}/api/delete", self.uri());
+        let url = format!("{}/api/delete", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .delete(uri)
+            .delete(url)
             .body(serialized)
             .send()
             .await

--- a/src/models/list_local.rs
+++ b/src/models/list_local.rs
@@ -6,10 +6,10 @@ use super::LocalModel;
 
 impl Ollama {
     pub async fn list_local_models(&self) -> crate::error::Result<Vec<LocalModel>> {
-        let uri = format!("{}/api/tags", self.uri());
+        let url = format!("{}/api/tags", self.url_str());
         let res = self
             .reqwest_client
-            .get(uri)
+            .get(url)
             .send()
             .await
             .map_err(|e| e.to_string())?;

--- a/src/models/list_local.rs
+++ b/src/models/list_local.rs
@@ -6,7 +6,7 @@ use super::LocalModel;
 
 impl Ollama {
     pub async fn list_local_models(&self) -> crate::error::Result<Vec<LocalModel>> {
-        let url = format!("{}/api/tags", self.url_str());
+        let url = format!("{}api/tags", self.url_str());
         let res = self
             .reqwest_client
             .get(url)

--- a/src/models/pull.rs
+++ b/src/models/pull.rs
@@ -28,7 +28,7 @@ impl Ollama {
             stream: true,
         };
 
-        let url = format!("{}/api/pull", self.url_str());
+        let url = format!("{}api/pull", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
@@ -79,7 +79,7 @@ impl Ollama {
             stream: false,
         };
 
-        let url = format!("{}/api/pull", self.url_str());
+        let url = format!("{}api/pull", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client

--- a/src/models/pull.rs
+++ b/src/models/pull.rs
@@ -28,11 +28,11 @@ impl Ollama {
             stream: true,
         };
 
-        let uri = format!("{}/api/pull", self.uri());
+        let url = format!("{}/api/pull", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await
@@ -79,11 +79,11 @@ impl Ollama {
             stream: false,
         };
 
-        let uri = format!("{}/api/pull", self.uri());
+        let url = format!("{}/api/pull", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await

--- a/src/models/push.rs
+++ b/src/models/push.rs
@@ -28,11 +28,11 @@ impl Ollama {
             stream: true,
         };
 
-        let uri = format!("{}/api/push", self.uri());
+        let url = format!("{}/api/push", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await
@@ -80,11 +80,11 @@ impl Ollama {
             stream: false,
         };
 
-        let uri = format!("{}/api/push", self.uri());
+        let url = format!("{}/api/push", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await

--- a/src/models/push.rs
+++ b/src/models/push.rs
@@ -28,7 +28,7 @@ impl Ollama {
             stream: true,
         };
 
-        let url = format!("{}/api/push", self.url_str());
+        let url = format!("{}api/push", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
@@ -80,7 +80,7 @@ impl Ollama {
             stream: false,
         };
 
-        let url = format!("{}/api/push", self.url_str());
+        let url = format!("{}api/push", self.url_str());
         let serialized = serde_json::to_string(&request).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client

--- a/src/models/show_info.rs
+++ b/src/models/show_info.rs
@@ -7,12 +7,12 @@ use super::ModelInfo;
 impl Ollama {
     /// Show details about a model including modelfile, template, parameters, license, and system prompt.
     pub async fn show_model_info(&self, model_name: String) -> crate::error::Result<ModelInfo> {
-        let uri = format!("{}/api/show", self.uri());
+        let url = format!("{}/api/show", self.url_str());
         let serialized =
             serde_json::to_string(&ModelInfoRequest { model_name }).map_err(|e| e.to_string())?;
         let res = self
             .reqwest_client
-            .post(uri)
+            .post(url)
             .body(serialized)
             .send()
             .await

--- a/src/models/show_info.rs
+++ b/src/models/show_info.rs
@@ -7,7 +7,7 @@ use super::ModelInfo;
 impl Ollama {
     /// Show details about a model including modelfile, template, parameters, license, and system prompt.
     pub async fn show_model_info(&self, model_name: String) -> crate::error::Result<ModelInfo> {
-        let url = format!("{}/api/show", self.url_str());
+        let url = format!("{}api/show", self.url_str());
         let serialized =
             serde_json::to_string(&ModelInfoRequest { model_name }).map_err(|e| e.to_string())?;
         let res = self


### PR DESCRIPTION
This makes `Ollama` store URLs instead of URIs (since Ollama can be mounted anywhere with a reverse proxy, ex: `http://example.com/path/to/ollama`).

I'm not quite sure if `.into()` will panic, so maybe the `# Panics` section in docstrings should be removed.

This does **not** break any old APIs, only adds new ones:

* `Ollama::from_url`
* `Ollama::url`
* `Ollama::url_str`
* `Ollama:new_with_history_from_url`
* `Ollama::try_new_with_history`
* `Ollama::try_new`

Closes #44