### PR TITLE
OllamaError for function-calling

### DIFF
--- a/src/generation/functions/mod.rs
+++ b/src/generation/functions/mod.rs
@@ -72,7 +72,7 @@ impl crate::Ollama {
             }
             Err(e) => {
                 self.add_assistant_response(id.clone(), e.message.clone().unwrap().content);
-                Ok(e)
+                Err(OllamaError::from(e.message.unwrap().content))
             }
         }
     }
@@ -100,7 +100,7 @@ impl crate::Ollama {
             .await;
         match result {
             Ok(r) => Ok(r),
-            Err(e) => Ok(e),
+            Err(e) => Err(OllamaError::from(e.message.unwrap().content)),
         }
     }
 }

--- a/tests/function_call.rs
+++ b/tests/function_call.rs
@@ -1,4 +1,4 @@
-// #![cfg(feature = "function-calling")]
+#![cfg(feature = "function-calling")]
 
 use ollama_rs::{
     generation::chat::ChatMessage,


### PR DESCRIPTION
- Parsing errors now return `OllamaError` now.
- Function calling test file feature dependency added