### PR TITLE
Fix panic when removing a message in the history with 0 value

### DIFF
--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -196,15 +196,16 @@ impl Ollama {
     /// Without impact for existing history
     /// Used to prepare history for request
     fn get_chat_messages_by_id(&mut self, history_id: impl ToString) -> Vec<ChatMessage> {
-        let mut binding = {
-            let new_history =
-                std::sync::Arc::new(std::sync::RwLock::new(MessagesHistory::default()));
-            self.messages_history = Some(new_history);
-            self.messages_history.clone().unwrap()
-        };
         let chat_history = match self.messages_history.as_mut() {
             Some(history) => history,
-            None => &mut binding,
+            None => {
+                self.messages_history = Some(std::sync::Arc::new(std::sync::RwLock::new(
+                    MessagesHistory::default(),
+                )));
+                self.messages_history
+                    .as_mut()
+                    .expect("Expect to fetch history")
+            }
         };
         // Clone the current chat messages to avoid borrowing issues
         // And not to add message to the history if the request fails

--- a/src/history.rs
+++ b/src/history.rs
@@ -34,12 +34,13 @@ impl MessagesHistory {
         // Replacing the oldest message if the limit is reached
         // The oldest message is the first one, unless it's a system message
         if messages.len() >= self.messages_number_limit as usize {
-            let index_to_remove = messages
-                .first()
-                .map(|m| if m.role == MessageRole::System { 1 } else { 0 })
-                .unwrap_or(0);
-
-            messages.remove(index_to_remove);
+            if let Some(index_to_remove) =
+                messages
+                    .first()
+                    .map(|m| if m.role == MessageRole::System { 1 } else { 0 })
+            {
+                messages.remove(index_to_remove);
+            }
         }
 
         if message.role == MessageRole::System {


### PR DESCRIPTION
## Description

It appears that when calling the `send_chat_messages_with_history_stream` method.  The`add_message` method  will try to remove a message by finding an index. Which by default is set to 0. https://github.com/pepperoni21/ollama-rs/blob/1900774b2472814baf7c7f44a3fce41f2cd6b4e0/src/history.rs#L42

For some unknown reason the `index_to_remove` variable can be equal to 0 and the fact that the `messages` vec can also be empty this means that the operation will panic

This PR aims to just to avoid panicking and only remove a message when the id is present