### PR TITLE
feat: Added suffix in completion request

### DIFF
--- a/src/generation/completion/request.rs
+++ b/src/generation/completion/request.rs
@@ -14,6 +14,7 @@ pub struct GenerationRequest {
     #[serde(rename = "model")]
     pub model_name: String,
     pub prompt: String,
+    pub suffix: Option<String>,
     pub images: Vec<Image>,
     pub options: Option<GenerationOptions>,
     pub system: Option<String>,
@@ -29,6 +30,7 @@ impl GenerationRequest {
         Self {
             model_name,
             prompt,
+            suffix: None,
             images: Vec::new(),
             options: None,
             system: None,
@@ -39,6 +41,18 @@ impl GenerationRequest {
             // Stream value will be overwritten by Ollama::generate_stream() and Ollama::generate() methods
             stream: false,
         }
+    }
+
+    /// Creates a new generation request with an suffix. Useful for code completion requests
+    pub fn new_with_suffix(model_name: String, prompt: String, suffix: String) -> Self {
+        let out = Self::new(model_name, prompt);
+        out.suffix(suffix)
+    }
+
+    /// Adds a text after the model response
+    pub fn suffix(mut self, suffix: String) -> Self {
+        self.suffix = Some(suffix);
+        self
     }
 
     /// A list of images to be used with the prompt

--- a/tests/code_completion.rs
+++ b/tests/code_completion.rs
@@ -1,0 +1,24 @@
+use ollama_rs::{
+    generation::{completion::request::GenerationRequest, options::GenerationOptions},
+    Ollama,
+};
+
+const CODE_MODEL: &str = "granite-code:3b";
+
+#[tokio::test]
+async fn typical_c_code_main() {
+    const C_PREFIX: &str = "int m";
+    const C_SUFFIX: &str = "(int argc, char **argv)";
+    const C_COMPLETION: &str = "ain";
+
+    let options = GenerationOptions::default().seed(146);
+    let request =
+        GenerationRequest::new_with_suffix(CODE_MODEL.into(), C_PREFIX.into(), C_SUFFIX.into())
+            .options(options);
+
+    let ollama = Ollama::default();
+    let res = ollama.generate(request).await.unwrap();
+
+    let completion = res.response;
+    assert_eq!(completion, C_COMPLETION);
+}


### PR DESCRIPTION
New ollama haves API for code completions by introducing field `suffix`: https://github.com/ollama/ollama/blob/608e87bf8707e377f1c195ae22330e26f67de91e/docs/api.md?plain=1#L43

This PR adds this field to request and also methods to init `suffix`. I've added small test as well to check everything is working with `granite-code:3b` model. 

