### PR TITLE
Add Tool Role to MessageRole Type

### DIFF
--- a/src/generation/chat/mod.rs
+++ b/src/generation/chat/mod.rs
@@ -297,4 +297,6 @@ pub enum MessageRole {
     Assistant,
     #[serde(rename = "system")]
     System,
+    #[serde(rename = "tool")]
+    Tool,
 }


### PR DESCRIPTION
# Add Support for `tool` Role in MessageRole

## Context:
Ollama supports 4 message roles:
- `system`
- `user`
- `assistant`
- `tool`

Currently, only the first three (`system`, `user`, `assistant`) are available in the `MessageRole` type.

## Changes:
- Add the `tool` role to the `MessageRole` type to fully support all roles available in Ollama.
  
This will allow the `tool` role to be used when sending messages.
