### PR TITLE
Llama multiple function calls + raw_mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/settings.json
 shell.nix
 .idea
+.DS_Store

--- a/src/generation/functions/mod.rs
+++ b/src/generation/functions/mod.rs
@@ -59,6 +59,10 @@ impl crate::Ollama {
             )
             .await?;
 
+        if request.raw_mode {
+            return Ok(tool_call_result);
+        }
+
         let tool_call_content: String = tool_call_result.message.clone().unwrap().content;
         let result = parser
             .parse(
@@ -96,8 +100,12 @@ impl crate::Ollama {
             request.chat.messages.insert(0, system_prompt);
         }
         let result = self.send_chat_messages(request.chat).await?;
-        let response_content: String = result.message.clone().unwrap().content;
 
+        if request.raw_mode {
+            return Ok(result);
+        }
+
+        let response_content: String = result.message.clone().unwrap().content;
         let result = parser
             .parse(&response_content, model_name, request.tools)
             .await;

--- a/src/generation/functions/request.rs
+++ b/src/generation/functions/request.rs
@@ -8,12 +8,17 @@ use std::sync::Arc;
 pub struct FunctionCallRequest {
     pub chat: ChatMessageRequest,
     pub tools: Vec<Arc<dyn Tool>>,
+    pub raw_mode: bool,
 }
 
 impl FunctionCallRequest {
     pub fn new(model_name: String, tools: Vec<Arc<dyn Tool>>, messages: Vec<ChatMessage>) -> Self {
         let chat = ChatMessageRequest::new(model_name, messages);
-        Self { chat, tools }
+        Self {
+            chat,
+            tools,
+            raw_mode: false,
+        }
     }
 
     /// Additional model parameters listed in the documentation for the Modelfile
@@ -31,6 +36,11 @@ impl FunctionCallRequest {
     // The format to return a response in. Currently the only accepted value is `json`
     pub fn format(mut self, format: FormatType) -> Self {
         self.chat.format = Some(format);
+        self
+    }
+
+    pub fn raw_mode(mut self) -> Self {
+        self.raw_mode = true;
         self
     }
 }

--- a/tests/function_call.rs
+++ b/tests/function_call.rs
@@ -47,14 +47,14 @@ async fn test_send_function_call_with_history() {
     /// - OpenAIFunctionCall: not model specific, degraded performance
     /// - NousFunctionCall: adrienbrault/nous-hermes2pro:Q8_0
     /// - LlamaFunctionCall: llama3.1:latest
-    const MODEL: &str = "adrienbrault/nous-hermes2pro:Q8_0";
+    const MODEL: &str = "phi3:14b-medium-4k-instruct-q4_1";
 
     const PROMPT: &str = "Aside from the Apple Remote, what other device can control the program Apple Remote was originally designed to interact with?";
     let user_message = ChatMessage::user(PROMPT.to_string());
 
     let scraper_tool = Arc::new(Scraper::new());
     let ddg_search_tool = Arc::new(DDGSearcher::new());
-    let parser = Arc::new(NousFunctionCall::new());
+    let parser = Arc::new(OpenAIFunctionCall {});
 
     let mut ollama = Ollama::new_default_with_history(30);
     let result = ollama
@@ -126,27 +126,27 @@ async fn test_send_function_call_llama() {
 }
 
 #[tokio::test]
-async fn test_send_function_call_phi3_medium() {
+async fn test_send_function_call_llama_raw() {
     /// Model to be used, make sure it is tailored towards "function calling", such as:
     /// - OpenAIFunctionCall: not model specific, degraded performance
     /// - NousFunctionCall: adrienbrault/nous-hermes2pro:Q8_0
     /// - LlamaFunctionCall: llama3.1:latest
-    const MODEL: &str = "phi3:14b-medium-4k-instruct-q4_1";
+    const MODEL: &str = "llama3.1:latest";
 
     const PROMPT: &str = "What are the current risk factors to Apple Inc?";
     let user_message = ChatMessage::user(PROMPT.to_string());
 
     let search = Arc::new(DDGSearcher::new());
-    let parser = Arc::new(OpenAIFunctionCall {});
+    let parser = Arc::new(LlamaFunctionCall {});
 
     let ollama = Ollama::default();
     let result = ollama
         .send_function_call(
-            FunctionCallRequest::new(MODEL.to_string(), vec![search], vec![user_message]),
+            FunctionCallRequest::new(MODEL.to_string(), vec![search], vec![user_message])
+                .raw_mode(),
             parser,
         )
         .await
         .unwrap();
-
     assert!(result.done);
 }


### PR DESCRIPTION
- Added support for multiple function calls for Llama3.1 models #75 
- Added raw_mode for function call, which results in returning raw function calls without executing the tools and returning results. You do this by simply calling raw_mode() at the end of the function call
```rust
    let result = ollama
        .send_function_call(
            FunctionCallRequest::new(MODEL.to_string(), vec![search], vec![user_message])
                .raw_mode(),
            parser,
        )
        .await
        .unwrap();
```