### PR TITLE
Remove "escaped" quotes from llama function output

### DIFF
--- a/src/generation/functions/pipelines/meta_llama/prompts.rs
+++ b/src/generation/functions/pipelines/meta_llama/prompts.rs
@@ -3,7 +3,7 @@ You have access to the following functions:
 {tools}
 If you choose to call a function ONLY reply in the following format with no prefix or suffix:
 
-<function=example_function_name>{{"example_name": "example_value"}}</function>
+<function=example_function_name>{{\"example_name\": \"example_value\"}}</function>
 
 Reminder:
 - Function calls MUST follow the specified format, start with <function= and end with </function>

--- a/src/generation/functions/pipelines/meta_llama/prompts.rs
+++ b/src/generation/functions/pipelines/meta_llama/prompts.rs
@@ -3,7 +3,7 @@ You have access to the following functions:
 {tools}
 If you choose to call a function ONLY reply in the following format with no prefix or suffix:
 
-<function=example_function_name>{{\"example_name\": \"example_value\"}}</function>
+<function=example_function_name>{{"example_name": "example_value"}}</function>
 
 Reminder:
 - Function calls MUST follow the specified format, start with <function= and end with </function>

--- a/src/generation/functions/pipelines/meta_llama/request.rs
+++ b/src/generation/functions/pipelines/meta_llama/request.rs
@@ -60,6 +60,7 @@ impl LlamaFunctionCall {
             .to_string()
             .replace("{{", "{")
             .replace("}}", "}")
+            .replace("\\\"", "\"")
     }
 
     fn parse_tool_response(&self, response: &str) -> Vec<LlamaFunctionCallSignature> {


### PR DESCRIPTION
This was causing function parse errors, since `\"` is different from `"`