### PR TITLE
Create Image::to_base64

### DIFF
--- a/src/generation/images.rs
+++ b/src/generation/images.rs
@@ -5,7 +5,7 @@ pub struct Image(String);
 
 impl Image {
     pub fn from_base64(base64: impl Into<String>) -> Self {
-        Self(base64.to_string())
+        Self(base64.into())
     }
 
     pub fn to_base64(&self) -> &str {

--- a/src/generation/images.rs
+++ b/src/generation/images.rs
@@ -4,7 +4,11 @@ use serde::{Deserialize, Serialize};
 pub struct Image(String);
 
 impl Image {
-    pub fn from_base64(base64: &str) -> Self {
+    pub fn from_base64(base64: impl Into<String>) -> Self {
         Self(base64.to_string())
+    }
+
+    pub fn to_base64(&self) -> &str {
+        &self.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ pub trait IntoUrl: IntoUrlSealed {}
 
 impl IntoUrl for Url {}
 impl IntoUrl for String {}
-impl<'a> IntoUrl for &'a str {}
-impl<'a> IntoUrl for &'a String {}
+impl IntoUrl for &str {}
+impl IntoUrl for &String {}
 
 pub trait IntoUrlSealed {
     fn into_url(self) -> Result<Url, url::ParseError>;
@@ -42,7 +42,7 @@ impl IntoUrlSealed for Url {
     }
 }
 
-impl<'a> IntoUrlSealed for &'a str {
+impl IntoUrlSealed for &str {
     fn into_url(self) -> Result<Url, url::ParseError> {
         Url::parse(self)?.into_url()
     }
@@ -52,7 +52,7 @@ impl<'a> IntoUrlSealed for &'a str {
     }
 }
 
-impl<'a> IntoUrlSealed for &'a String {
+impl IntoUrlSealed for &String {
     fn into_url(self) -> Result<Url, url::ParseError> {
         (&**self).into_url()
     }


### PR DESCRIPTION
This opens up the possibility of models sending back images, and clients being able to get the image contents as base64.
I've also updated `from_base64` to take an `impl Into<String>`, meaning the function will be happy to take an `&str` _or_ a `String`, and run `cargo clippy --fix`