### PR TITLE
fix: Function calling returns invalid tool call as valid chat response

### DIFF
--- a/src/generation/functions/mod.rs
+++ b/src/generation/functions/mod.rs
@@ -65,7 +65,7 @@ impl crate::Ollama {
             return Ok(tool_call_result);
         }
 
-        let tool_call_content: String = tool_call_result.message.clone().unwrap().content;
+        let tool_call_content: String = tool_call_result.message.unwrap().content;
         let result = parser
             .parse(
                 &tool_call_content,
@@ -80,8 +80,8 @@ impl crate::Ollama {
                 Ok(r)
             }
             Err(e) => {
-                self.add_assistant_response(id.clone(), e.message.clone().unwrap().content);
-                Err(OllamaError::from(e.message.unwrap().content))
+                self.add_assistant_response(id.clone(), e.message.clone());
+                Err(e)
             }
         }
     }
@@ -108,12 +108,8 @@ impl crate::Ollama {
         }
 
         let response_content: String = result.message.clone().unwrap().content;
-        let result = parser
+        return parser
             .parse(&response_content, model_name, request.tools)
             .await;
-        match result {
-            Ok(r) => Ok(r),
-            Err(e) => Err(OllamaError::from(e.message.unwrap().content)),
-        }
     }
 }

--- a/src/generation/functions/pipelines/mod.rs
+++ b/src/generation/functions/pipelines/mod.rs
@@ -15,7 +15,7 @@ pub trait RequestParserBase: Send + Sync {
         input: &str,
         model_name: String,
         tools: Vec<Arc<dyn Tool>>,
-    ) -> Result<ChatMessageResponse, ChatMessageResponse>;
+    ) -> Result<ChatMessageResponse, OllamaError>;
     fn format_query(&self, input: &str) -> String {
         input.to_string()
     }
@@ -23,5 +23,4 @@ pub trait RequestParserBase: Send + Sync {
         response.to_string()
     }
     async fn get_system_message(&self, tools: &[Arc<dyn Tool>]) -> ChatMessage;
-    fn error_handler(&self, error: OllamaError) -> ChatMessageResponse;
 }


### PR DESCRIPTION
fixes https://github.com/pepperoni21/ollama-rs/issues/92

Offending line: https://github.com/pepperoni21/ollama-rs/blob/1728591e2236de11391514faf3ea82f506f682ff/src/generation/functions/pipelines/meta_llama/request.rs#L117

Passing up the `OllamaError` also allows the caller to determine how to handle the error, rather than being hidden by the parser.