### PR TITLE
Adding online model listing.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ stream = ["tokio-stream", "reqwest/stream", "tokio"]
 rustls = ["reqwest/rustls-tls"]
 headers = ["http"]
 tool-implementations = ["scraper", "text-splitter", "regex", "calc", "html2md"]
+regex = ["dep:regex"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This library was created following the [Ollama API](https://github.com/jmorganca
   - [Completion Generation (With Options)](#completion-generation-with-options)
   - [Chat Mode](#chat-mode)
   - [List Local Models](#list-local-models)
+  - [List Online Models](#list-online-models)
   - [Show Model Information](#show-model-information)
   - [Create a Model](#create-a-model)
   - [Create a Model (Streaming)](#create-a-model-streaming)
@@ -159,6 +160,16 @@ let res = ollama.list_local_models().await.unwrap();
 ```
 
 _Returns a vector of `LocalModel` structs._
+
+### List Online Models
+
+_Requires the `regex` crate._
+
+```rust
+let res = ollama.list_online_models(None).await.unwrap();
+```
+
+_Returns model name in a vector of `strings`._
 
 ### Show Model Information
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,6 +2,7 @@ pub mod copy;
 pub mod create;
 pub mod delete;
 pub mod list_local;
+pub mod list_online;
 pub mod pull;
 pub mod push;
 pub mod show_info;

--- a/src/models/list_online.rs
+++ b/src/models/list_online.rs
@@ -1,0 +1,48 @@
+use regex::Regex;
+use crate::{error::OllamaError, Ollama};
+
+fn extract_models_from_html(data: String) -> Vec<String> {
+  let mut models: Vec<String> = Vec::new();
+
+  // This is the regular expression to
+  // capture models names in HTML content.
+  let re = Regex::new(r"<span x-test-search-response-title>(.*?)</span>").unwrap();
+
+  for cap in re.captures_iter(data.as_str()) {
+    models.push(cap[1].to_string());
+  }
+
+  return models
+}
+
+impl Ollama {
+  pub async fn list_online_models(&self, model_type: Option<&str>) -> crate::error::Result<Vec<String>> {
+    let mut online_ollama_url = "https://ollama.com/search".to_string();
+
+    match model_type.as_deref() {
+      Some("vision") | Some("tools") | Some("embedding") => {
+        online_ollama_url = format!("{}?c={}", online_ollama_url, model_type.unwrap());
+      }
+      None => {}
+      _ => return Err(crate::error::OllamaError::Other("Please select a valid type.".to_string())),
+    }
+
+    let builder = self.reqwest_client.get(online_ollama_url);
+
+    #[cfg(feature = "headers")]
+    let builder = builder.headers(self.request_headers.clone());
+
+    let res = builder.send().await?;
+
+    if !res.status().is_success() {
+      return Err(OllamaError::Other(res.text().await?));
+    }
+
+    let response = res.bytes().await?;
+    let data = String::from_utf8(response.to_vec()).unwrap();
+    let models = extract_models_from_html(data);
+
+    // let models: Vec<String> = vec!["abc".to_string(), "def".to_string(), "ghi".to_string()];
+    Ok(models)
+  }
+}

--- a/src/models/list_online.rs
+++ b/src/models/list_online.rs
@@ -42,7 +42,6 @@ impl Ollama {
     let data = String::from_utf8(response.to_vec()).unwrap();
     let models = extract_models_from_html(data);
 
-    // let models: Vec<String> = vec!["abc".to_string(), "def".to_string(), "ghi".to_string()];
     Ok(models)
   }
 }

--- a/tests/list_online_models.rs
+++ b/tests/list_online_models.rs
@@ -1,0 +1,11 @@
+#[tokio::test]
+async fn test_list_online_models() {
+  let ollama = ollama_rs::Ollama::default();
+
+  // let models = ollama.list_online_models(Some("vision")).await.unwrap();
+  // let models = ollama.list_online_models(Some("tools")).await.unwrap();
+  // let models = ollama.list_online_models(Some("embedding")).await.unwrap();
+  let models = ollama.list_online_models(None).await.unwrap();
+
+  dbg!(models);
+}


### PR DESCRIPTION
Hi 👋,

This pull request adds a function named `list_online_models` that retrieves model names from Ollama.
This function can list every available models from Ollama and filter them by keywords `vision`, `tools` and `embedding`.

Filters from https://ollama.com/search :

<img width="526" alt="image" src="https://github.com/user-attachments/assets/e23fdafa-692b-4014-ace8-f7bcf3f6b7af" />

It uses an HTTP web request to the official Ollama website and use regex to extract model names.