### PR TITLE
Added tool_group macro

### DIFF
--- a/ollama-rs-macros/src/lib.rs
+++ b/ollama-rs-macros/src/lib.rs
@@ -1,8 +1,14 @@
 use proc_macro::TokenStream;
 
 mod function;
+mod tool_group;
 
 #[proc_macro_attribute]
 pub fn function(attr: TokenStream, value: TokenStream) -> TokenStream {
     function::function_impl(attr, value)
+}
+
+#[proc_macro]
+pub fn tool_group(attr: TokenStream) -> TokenStream {
+    tool_group::tool_group_impl(attr)
 }

--- a/ollama-rs-macros/src/tool_group.rs
+++ b/ollama-rs-macros/src/tool_group.rs
@@ -1,0 +1,25 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, punctuated::Punctuated, Expr, Token};
+
+pub fn tool_group_impl(input: TokenStream) -> TokenStream {
+    let expr_array = parse_macro_input!(input with Punctuated::<Expr, Token![,]>::parse_terminated);
+
+    if expr_array.is_empty() {
+        return TokenStream::from(quote! {
+            ()
+        });
+    }
+
+    let nested_tuples = expr_array
+        .into_iter()
+        .rev()
+        .reduce(|acc, expr| syn::parse_quote!((#expr, #acc)))
+        .unwrap();
+
+    let expanded = quote! {
+        #nested_tuples
+    };
+
+    TokenStream::from(expanded)
+}

--- a/ollama-rs/examples/function_call.rs
+++ b/ollama-rs/examples/function_call.rs
@@ -20,17 +20,29 @@ async fn get_available_space(path: PathBuf) -> Result<String, Box<dyn std::error
     ))
 }
 
+/// Get the weather for a given city.
+///
+/// * city - City to get the weather for.
+#[ollama_rs::function]
+async fn get_weather(city: String) -> Result<String, Box<dyn std::error::Error>> {
+    Ok(reqwest::get(format!("https://wttr.in/{city}?format=%C+%t"))
+        .await?
+        .text()
+        .await?)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ollama = Ollama::default();
     let history = vec![];
-    let tools = (get_cpu_temperature, get_available_space);
+    let tools = ollama_rs::tool_group![get_cpu_temperature, get_available_space, get_weather];
     let mut coordinator =
         Coordinator::new_with_tools(ollama, "llama3.2".to_string(), history, tools);
 
     let user_messages = vec![
         "What's the CPU temperature?",
         "What's the available space in the root directory?",
+        "What's the weather in Berlin?",
     ];
 
     for user_message in user_messages {

--- a/ollama-rs/src/lib.rs
+++ b/ollama-rs/src/lib.rs
@@ -3,7 +3,7 @@
 use url::Url;
 
 #[cfg(feature = "macros")]
-pub use ollama_rs_macros::function;
+pub use ollama_rs_macros::{function, tool_group};
 
 pub mod coordinator;
 pub mod error;


### PR DESCRIPTION
Added a tool_group macro that allows to specify an array of tools for adding more than 2 tools in an easier way.

Example:
```rust
let tools = ollama_rs::tool_group![get_cpu_temperature, get_available_space, get_weather];
```

Fixes https://github.com/pepperoni21/ollama-rs/issues/111