### PR TITLE
Support for aborting requests

### DIFF
--- a/ollama-rs/src/error.rs
+++ b/ollama-rs/src/error.rs
@@ -15,6 +15,8 @@ pub enum OllamaError {
     ReqwestError(#[from] reqwest::Error),
     #[error("Internal Ollama error")]
     InternalError(InternalOllamaError),
+    #[error("Ollama aborted the request")]
+    Abort,
     #[error("Error in Ollama")]
     Other(String),
 }

--- a/ollama-rs/src/generation/completion/request.rs
+++ b/ollama-rs/src/generation/completion/request.rs
@@ -1,3 +1,5 @@
+use std::sync::{atomic::AtomicBool, Arc};
+
 use serde::Serialize;
 
 use crate::generation::{
@@ -7,6 +9,28 @@ use crate::generation::{
 };
 
 use super::GenerationContext;
+
+#[derive(Debug, Clone)]
+pub struct AbortSignal {
+    pub(crate) abort_signal: Arc<AtomicBool>,
+}
+
+impl AbortSignal {
+    pub fn new() -> Self {
+        Self {
+            abort_signal: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn abort(&self) {
+        self.abort_signal
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn aborted(&self) -> bool {
+        self.abort_signal.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
 
 /// A generation request to Ollama.
 #[derive(Debug, Clone, Serialize)]
@@ -24,6 +48,8 @@ pub struct GenerationRequest {
     pub format: Option<FormatType>,
     pub keep_alive: Option<KeepAlive>,
     pub(crate) stream: bool,
+    #[serde(skip)]
+    pub abort_signal: Option<AbortSignal>,
 }
 
 impl GenerationRequest {
@@ -41,6 +67,7 @@ impl GenerationRequest {
             keep_alive: None,
             // Stream value will be overwritten by Ollama::generate_stream() and Ollama::generate() methods
             stream: false,
+            abort_signal: None,
         }
     }
 
@@ -101,6 +128,12 @@ impl GenerationRequest {
     /// Used to control how long a model stays loaded in memory, by default models are unloaded after 5 minutes of inactivity
     pub fn keep_alive(mut self, keep_alive: KeepAlive) -> Self {
         self.keep_alive = Some(keep_alive);
+        self
+    }
+
+    /// Sets the abort signal for the request
+    pub fn abort_signal(mut self, abort_signal: AbortSignal) -> Self {
+        self.abort_signal = Some(abort_signal);
         self
     }
 }


### PR DESCRIPTION
Currently only implemented for `generate_stream`.

An optional `AbortSignal` is added onto the `GenerationRequest` struct, which is a wrapper for `Arc<AtomicBool>` that allows sending the abort signal by setting it to true.

Fixes https://github.com/pepperoni21/ollama-rs/issues/89