### PR TITLE
Multiple struct fields not working with `function` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +601,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +987,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "macrotest"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2035deb453578ff1cd2da2761ac78abbffffd1d06a0f59261c082ea713fdad"
+dependencies = [
+ "basic-toml",
+ "diff",
+ "glob",
+ "prettyplease",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,6 +1166,7 @@ dependencies = [
 name = "ollama-rs-macros"
 version = "0.2.3"
 dependencies = [
+ "macrotest",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -1358,6 +1390,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.95",
+]
 
 [[package]]
 name = "proc-macro-error"

--- a/ollama-rs-macros/Cargo.toml
+++ b/ollama-rs-macros/Cargo.toml
@@ -14,3 +14,6 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+macrotest = "1"

--- a/ollama-rs-macros/src/function.rs
+++ b/ollama-rs-macros/src/function.rs
@@ -120,7 +120,7 @@ fn build_params_struct(input: &ItemFn, docs: &FunctionDocs) -> syn::Result<Param
         #[allow(non_camel_case_types, missing_docs)]
         #[derive(::serde::Deserialize, ::schemars::JsonSchema)]
         pub struct #name {
-            #(#fields),*
+            #(#fields)*
         }
     );
 

--- a/ollama-rs-macros/tests/expand/fn_multi_arg.expanded.rs
+++ b/ollama-rs-macros/tests/expand/fn_multi_arg.expanded.rs
@@ -9,6 +9,8 @@ mod __hello_world_data {
     pub struct __hello_world__Params {
         ///The phrase to use for greeting
         pub greeting: String,
+        ///Whom to say hello to
+        pub name: String,
     }
 }
 #[allow(non_camel_case_types)]
@@ -35,6 +37,52 @@ impl ::ollama_rs::generation::tools::Tool for hello_world {
                 ::alloc::__export::must_use({
                     let res = ::alloc::fmt::format(
                         format_args!("{0} {1}", greeting, name),
+                    );
+                    res
+                }),
+            )
+        }
+    }
+}
+#[doc(hidden)]
+mod __dummy_data {
+    #[allow(unused_imports)]
+    use super::*;
+    #[doc(hidden)]
+    #[allow(non_camel_case_types, missing_docs)]
+    pub struct __dummy__Params {
+        ///Arg one
+        pub one: String,
+        ///Arg two
+        pub two: i32,
+        ///Arg three
+        pub three: bool,
+    }
+}
+#[allow(non_camel_case_types)]
+struct dummy;
+impl ::ollama_rs::generation::tools::Tool for dummy {
+    type Params = __dummy_data::__dummy__Params;
+    #[inline]
+    fn name() -> &'static str {
+        "dummy"
+    }
+    #[inline]
+    fn description() -> &'static str {
+        "Dummy"
+    }
+    async fn call(
+        &mut self,
+        Self::Params { one, two, three }: Self::Params,
+    ) -> ::std::result::Result<
+        ::std::string::String,
+        ::std::boxed::Box<dyn ::std::error::Error>,
+    > {
+        {
+            Ok(
+                ::alloc::__export::must_use({
+                    let res = ::alloc::fmt::format(
+                        format_args!("{0} {1} {2}", greeting, name, three),
                     );
                     res
                 }),

--- a/ollama-rs-macros/tests/expand/fn_multi_arg.expanded.rs
+++ b/ollama-rs-macros/tests/expand/fn_multi_arg.expanded.rs
@@ -1,0 +1,44 @@
+#[macro_use]
+extern crate ollama_rs_macros;
+#[doc(hidden)]
+mod __hello_world_data {
+    #[allow(unused_imports)]
+    use super::*;
+    #[doc(hidden)]
+    #[allow(non_camel_case_types, missing_docs)]
+    pub struct __hello_world__Params {
+        ///The phrase to use for greeting
+        pub greeting: String,
+    }
+}
+#[allow(non_camel_case_types)]
+struct hello_world;
+impl ::ollama_rs::generation::tools::Tool for hello_world {
+    type Params = __hello_world_data::__hello_world__Params;
+    #[inline]
+    fn name() -> &'static str {
+        "hello_world"
+    }
+    #[inline]
+    fn description() -> &'static str {
+        "Say something"
+    }
+    async fn call(
+        &mut self,
+        Self::Params { greeting, name }: Self::Params,
+    ) -> ::std::result::Result<
+        ::std::string::String,
+        ::std::boxed::Box<dyn ::std::error::Error>,
+    > {
+        {
+            Ok(
+                ::alloc::__export::must_use({
+                    let res = ::alloc::fmt::format(
+                        format_args!("{0} {1}", greeting, name),
+                    );
+                    res
+                }),
+            )
+        }
+    }
+}

--- a/ollama-rs-macros/tests/expand/fn_multi_arg.rs
+++ b/ollama-rs-macros/tests/expand/fn_multi_arg.rs
@@ -10,3 +10,14 @@ async fn hello_world(greeting: String, name: String) -> Result<String, Box<dyn s
 
     Ok(format!("{} {}", greeting, name))
 }
+
+/// Dummy
+///
+/// * one - Arg one
+/// * two - Arg two
+/// * three - Arg three
+#[function]
+async fn dummy(one: String, two: i32, three: bool) -> Result<String, Box<dyn std::error::Error>> {
+
+    Ok(format!("{} {} {}", greeting, name, three))
+}

--- a/ollama-rs-macros/tests/expand/fn_multi_arg.rs
+++ b/ollama-rs-macros/tests/expand/fn_multi_arg.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate ollama_rs_macros;
+
+/// Say something
+///
+/// * greeting - The phrase to use for greeting
+/// * name - Whom to say hello to
+#[function]
+async fn hello_world(greeting: String, name: String) -> Result<String, Box<dyn std::error::Error>> {
+
+    Ok(format!("{} {}", greeting, name))
+}

--- a/ollama-rs-macros/tests/expand/fn_no_args.expanded.rs
+++ b/ollama-rs-macros/tests/expand/fn_no_args.expanded.rs
@@ -1,0 +1,32 @@
+#[macro_use]
+extern crate ollama_rs_macros;
+#[doc(hidden)]
+mod __hello_world_data {
+    #[allow(unused_imports)]
+    use super::*;
+    #[doc(hidden)]
+    #[allow(non_camel_case_types, missing_docs)]
+    pub struct __hello_world__Params {}
+}
+#[allow(non_camel_case_types)]
+struct hello_world;
+impl ::ollama_rs::generation::tools::Tool for hello_world {
+    type Params = __hello_world_data::__hello_world__Params;
+    #[inline]
+    fn name() -> &'static str {
+        "hello_world"
+    }
+    #[inline]
+    fn description() -> &'static str {
+        "Say hello"
+    }
+    async fn call(
+        &mut self,
+        Self::Params {}: Self::Params,
+    ) -> ::std::result::Result<
+        ::std::string::String,
+        ::std::boxed::Box<dyn ::std::error::Error>,
+    > {
+        { Ok("Hello".to_string()) }
+    }
+}

--- a/ollama-rs-macros/tests/expand/fn_no_args.rs
+++ b/ollama-rs-macros/tests/expand/fn_no_args.rs
@@ -1,0 +1,9 @@
+#[macro_use]
+extern crate ollama_rs_macros;
+
+/// Say hello
+#[function]
+async fn hello_world() -> Result<String, Box<dyn std::error::Error>> {
+
+    Ok("Hello".to_string())
+}

--- a/ollama-rs-macros/tests/expand/fn_one_arg.expanded.rs
+++ b/ollama-rs-macros/tests/expand/fn_one_arg.expanded.rs
@@ -1,0 +1,42 @@
+#[macro_use]
+extern crate ollama_rs_macros;
+#[doc(hidden)]
+mod __hello_world_data {
+    #[allow(unused_imports)]
+    use super::*;
+    #[doc(hidden)]
+    #[allow(non_camel_case_types, missing_docs)]
+    pub struct __hello_world__Params {
+        ///Whom to say hello to
+        pub name: String,
+    }
+}
+#[allow(non_camel_case_types)]
+struct hello_world;
+impl ::ollama_rs::generation::tools::Tool for hello_world {
+    type Params = __hello_world_data::__hello_world__Params;
+    #[inline]
+    fn name() -> &'static str {
+        "hello_world"
+    }
+    #[inline]
+    fn description() -> &'static str {
+        "Say hello"
+    }
+    async fn call(
+        &mut self,
+        Self::Params { name }: Self::Params,
+    ) -> ::std::result::Result<
+        ::std::string::String,
+        ::std::boxed::Box<dyn ::std::error::Error>,
+    > {
+        {
+            Ok(
+                ::alloc::__export::must_use({
+                    let res = ::alloc::fmt::format(format_args!("Hello {0}", name));
+                    res
+                }),
+            )
+        }
+    }
+}

--- a/ollama-rs-macros/tests/expand/fn_one_arg.rs
+++ b/ollama-rs-macros/tests/expand/fn_one_arg.rs
@@ -1,0 +1,11 @@
+#[macro_use]
+extern crate ollama_rs_macros;
+
+/// Say hello
+///
+/// * name - Whom to say hello to
+#[function]
+async fn hello_world(name: String) -> Result<String, Box<dyn std::error::Error>> {
+
+    Ok(format!("Hello {}", name))
+}

--- a/ollama-rs-macros/tests/tests.rs
+++ b/ollama-rs-macros/tests/tests.rs
@@ -1,0 +1,4 @@
+#[test]
+pub fn pass() {
+    macrotest::expand("tests/expand/*.rs");
+}


### PR DESCRIPTION
I was playing around with the new macros crate and ran into an issue where functions with multiple parameters were not working. This PR includes tests and a fix to get things working. The tests are snapshot tests so the first commit shows the original output and the second commit shows how it changes.

Original output: https://github.com/pepperoni21/ollama-rs/commit/9efa18821535bad6ca54ba9632a575dc628f09d3#diff-96d7077f55b633c5d8d988ab8d40b3ab537c4373054cbd24ccc0eea8d66cd76fR9-R12
Original function definition: https://github.com/pepperoni21/ollama-rs/commit/9efa18821535bad6ca54ba9632a575dc628f09d3#diff-21c6d56dc212eca87d62636970bad00dddbc081203f5572b381df6504eb48c11R4-R9

The tests use `cargo expand`, so you may not want to include. If you do, the workflows might need an update. Let me know either way or just yoink the fix :D