### PR TITLE
OllamaError should be Send + Sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "static_assertions",
  "text-splitter",
  "thiserror 2.0.9",
  "tokio",
@@ -1969,6 +1970,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str-buf"

--- a/ollama-rs/Cargo.toml
+++ b/ollama-rs/Cargo.toml
@@ -30,6 +30,7 @@ schemars = { version = "0.8.21", features = ["preserve_order"] }
 thiserror = "2.0.9"
 calc = { version = "0.4.0", optional = true }
 html2md = { version = "0.2.14", optional = true }
+static_assertions = "1.1.0"
 
 ollama-rs-macros = { workspace = true, optional = true }
 

--- a/ollama-rs/src/error.rs
+++ b/ollama-rs/src/error.rs
@@ -1,5 +1,8 @@
 use serde::Deserialize;
+use static_assertions::assert_impl_all;
 use thiserror::Error;
+
+assert_impl_all!(OllamaError: Send, Sync);
 
 /// A result type for ollama-rs.
 pub type Result<T> = std::result::Result<T, OllamaError>;
@@ -34,5 +37,5 @@ pub enum ToolCallError {
     )]
     InvalidToolArguments(#[from] serde_json::Error),
     #[error("Tool errored internally when it was called")]
-    InternalToolError(#[from] Box<dyn std::error::Error>),
+    InternalToolError(#[from] Box<dyn std::error::Error + Send + Sync>),
 }

--- a/ollama-rs/src/generation/tools/implementations/browserless.rs
+++ b/ollama-rs/src/generation/tools/implementations/browserless.rs
@@ -29,7 +29,7 @@ impl Tool for Browserless {
         "Scrapes text content from websites and splits it into manageable chunks."
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<String, Box<dyn Error>> {
+    async fn call(&mut self, params: Self::Params) -> Result<String, Box<dyn Error + Sync + Send>> {
         let website = params.website;
         let browserless_token =
             env::var("BROWSERLESS_TOKEN").expect("BROWSERLESS_TOKEN must be set");

--- a/ollama-rs/src/generation/tools/implementations/calc.rs
+++ b/ollama-rs/src/generation/tools/implementations/calc.rs
@@ -31,7 +31,7 @@ impl Tool for Calculator {
     async fn call(
         &mut self,
         parameters: Self::Params,
-    ) -> Result<String, Box<dyn std::error::Error>> {
+    ) -> Result<String, Box<dyn std::error::Error + Sync + Send>> {
         let mut ctx: Context<f64> = Context::default();
 
         let res = match ctx.evaluate(&parameters.expression) {

--- a/ollama-rs/src/generation/tools/implementations/finance.rs
+++ b/ollama-rs/src/generation/tools/implementations/finance.rs
@@ -39,7 +39,7 @@ impl StockScraper {
         &self,
         exchange: &str,
         ticker: &str,
-    ) -> Result<HashMap<String, String>, Box<dyn Error>> {
+    ) -> Result<HashMap<String, String>, Box<dyn Error + Send + Sync>> {
         let target_url = format!(
             "{}/quote/{}:{}?hl={}",
             self.base_url, ticker, exchange, self.language
@@ -81,7 +81,7 @@ impl Tool for StockScraper {
         "Scrapes stock information from Google Finance."
     }
 
-    async fn call(&mut self, params: Params) -> Result<String, Box<dyn Error>> {
+    async fn call(&mut self, params: Params) -> Result<String, Box<dyn Error + Sync + Send>> {
         let result = self.scrape(&params.exchange, &params.ticker).await?;
         Ok(serde_json::to_string(&result)?)
     }

--- a/ollama-rs/src/generation/tools/implementations/scraper.rs
+++ b/ollama-rs/src/generation/tools/implementations/scraper.rs
@@ -36,7 +36,7 @@ impl Tool for Scraper {
         "Scrapes text content from websites and splits it into manageable chunks."
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<String, Box<dyn Error>> {
+    async fn call(&mut self, params: Self::Params) -> Result<String, Box<dyn Error + Sync + Send>> {
         let client = Client::new();
         let response = client.get(params.website).send().await?.text().await?;
 

--- a/ollama-rs/src/generation/tools/implementations/search_ddg.rs
+++ b/ollama-rs/src/generation/tools/implementations/search_ddg.rs
@@ -40,7 +40,7 @@ impl DDGSearcher {
         }
     }
 
-    pub async fn search(&self, query: &str) -> Result<Vec<SearchResult>, Box<dyn Error>> {
+    pub async fn search(&self, query: &str) -> Result<Vec<SearchResult>, Box<dyn Error + Send + Sync>> {
         let url = format!("{}/html/?q={}", self.base_url, query);
         let resp = self.client.get(&url).send().await?;
         let body = resp.text().await?;
@@ -102,7 +102,7 @@ impl Tool for DDGSearcher {
         "Searches the web using DuckDuckGo's HTML interface."
     }
 
-    async fn call(&mut self, params: Params) -> Result<String, Box<dyn Error>> {
+    async fn call(&mut self, params: Params) -> Result<String, Box<dyn Error + Sync + Send>> {
         let results = self.search(&params.query).await?;
         let results_json = serde_json::to_string(&results)?;
         Ok(results_json)

--- a/ollama-rs/src/generation/tools/implementations/serper.rs
+++ b/ollama-rs/src/generation/tools/implementations/serper.rs
@@ -233,7 +233,7 @@ impl Tool for SerperSearchTool {
         "Conducts a web search using a specified search type and returns the results."
     }
 
-    async fn call(&mut self, params: Params) -> Result<String, Box<dyn Error>> {
+    async fn call(&mut self, params: Params) -> Result<String, Box<dyn Error + Sync + Send>> {
         let lang = params.lang.as_deref().unwrap_or("en");
         let url = format!("https://google.serper.dev/{}", params.search_type.name());
         let gl = if lang != "en" { lang } else { "us" };

--- a/ollama-rs/src/generation/tools/mod.rs
+++ b/ollama-rs/src/generation/tools/mod.rs
@@ -25,7 +25,7 @@ pub trait Tool {
     fn call(
         &mut self,
         parameters: Self::Params,
-    ) -> impl Future<Output = Result<String, Box<dyn Error>>>;
+    ) -> impl Future<Output = Result<String, Box<dyn Error + Sync + Send>>>;
 }
 
 pub trait Parameters: DeserializeOwned + JsonSchema {}


### PR DESCRIPTION
OllamaError is not currently Send + Sync due to the trait bounds on the [from] in InternalToolError. This prevents Result<T, OllamaError> from being held/used across awaits. This code changes fixes that issue.

It also adds a compile time assert for validation.