### PR TITLE
feat: added ability to init ollama with pre-configured reqwest client

### DIFF
--- a/ollama-rs/src/lib.rs
+++ b/ollama-rs/src/lib.rs
@@ -119,6 +119,33 @@ impl Ollama {
         Self::from_url(url)
     }
 
+    /// Creates a new `Ollama` instance with the specified host, port, and `reqwest` client.
+    ///
+    /// # Arguments
+    ///
+    /// * `host` - The host of the Ollama service.
+    /// * `port` - The port of the Ollama service.
+    /// * `reqwest_client` - The `reqwest` client instance.
+    ///
+    /// # Returns
+    ///
+    /// A new `Ollama` instance with the specified `reqwest` client.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the host is not a valid URL or if the URL cannot have a port.
+    pub fn new_with_client(host: impl IntoUrl, port: u16, reqwest_client: reqwest::Client) -> Self {
+        let mut url: Url = host.into_url().unwrap();
+        url.set_port(Some(port)).unwrap();
+
+        Self {
+            url,
+            reqwest_client,
+            #[cfg(feature = "headers")]
+            request_headers: reqwest::header::HeaderMap::new(),
+        }
+    }
+
     /// Attempts to create a new `Ollama` instance from a URL.
     ///
     /// # Arguments


### PR DESCRIPTION
Recent versions of ollama have the tendency to hang/crash leaving requests to wait indefinitely. 
Because of that, it would be useful to allow for more control over the underlying `reqwest` client so that the user could set their own arbitrary timeout or other connection-related settings like proxies and etc.
I added a new constructor that allows the user to pass their own `reqwest` client to be used for making requests to ollama. I tried to follow the established code structure as much as possible, but I would suggest evaluating the possibility of moving to a builder pattern instead of supporting multiple constructors. I could help with that (while ensuring backwards-compatibility), if deemed appropriate.