### PR TITLE
Coordinator structured output

### DIFF
--- a/ollama-rs/Cargo.toml
+++ b/ollama-rs/Cargo.toml
@@ -13,6 +13,10 @@ readme = "../README.md"
 name = "function_call"
 required-features = ["macros"]
 
+[[example]]
+name = "function_call_structured"
+required-features = ["macros"]
+
 [dependencies]
 reqwest = { version = "0.12.12", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }

--- a/ollama-rs/examples/function_call_structured.rs
+++ b/ollama-rs/examples/function_call_structured.rs
@@ -2,8 +2,11 @@ use std::path::PathBuf;
 
 use ollama_rs::{
     coordinator::Coordinator,
-    generation::chat::ChatMessage,
-    generation::parameters::{FormatType, JsonSchema, JsonStructure},
+    generation::{
+        chat::ChatMessage,
+        options::GenerationOptions,
+        parameters::{FormatType, JsonSchema, JsonStructure},
+    },
     Ollama,
 };
 
@@ -33,7 +36,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
     let format = FormatType::StructuredJson(JsonStructure::new::<Weather>());
 
     let mut coordinator =
-        Coordinator::new_with_tools(ollama, "llama3.2".to_string(), history, tools).format(format);
+        Coordinator::new_with_tools(ollama, "llama3.2".to_string(), history, tools)
+            .format(format)
+            .options(GenerationOptions::default().temperature(0.0));
 
     let user_messages = vec!["What's the weather in Nanaimo?"];
 

--- a/ollama-rs/examples/function_call_structured.rs
+++ b/ollama-rs/examples/function_call_structured.rs
@@ -1,0 +1,62 @@
+use std::path::PathBuf;
+
+use ollama_rs::{
+    coordinator::Coordinator,
+    generation::chat::ChatMessage,
+    generation::parameters::{FormatType, JsonSchema, JsonStructure},
+    Ollama,
+};
+
+use serde::Deserialize;
+
+/// Get the weather for a given city.
+///
+/// * city - City to get the weather for.
+#[ollama_rs::function]
+async fn get_weather(city: String) -> Result<String, Box<dyn std::error::Error + Sync + Send>> {
+    println!("Get weather function called for {city}");
+    Ok(
+        reqwest::get(format!("https://wttr.in/{city}?format=%C+%t+%w+%P"))
+            .await?
+            .text()
+            .await?,
+    )
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
+    //let ollama = Ollama::default();
+    let ollama = Ollama::new("http://ryzen.local".to_string(), 11434);
+
+    let history = vec![];
+    let tools = ollama_rs::tool_group![get_weather];
+
+    let format = FormatType::StructuredJson(JsonStructure::new::<Weather>());
+
+    let mut coordinator =
+        Coordinator::new_with_tools(ollama, "llama3.2".to_string(), history, tools).format(format);
+
+    let user_messages = vec!["What's the weather in Nanaimo?"];
+
+    for user_message in user_messages {
+        println!("User: {user_message}");
+
+        let user_message = ChatMessage::user(user_message.to_owned());
+        let resp = coordinator.chat(vec![user_message]).await?;
+        println!("Assistant: {}", resp.message.content);
+    }
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema, Deserialize, Debug)]
+struct Weather {
+    city: String,
+    temperature_units: String,
+    temperature: f32,
+    wind_units: String,
+    wind: f32,
+    pressure_units: String,
+    pressure: f32,
+}

--- a/ollama-rs/examples/function_call_structured.rs
+++ b/ollama-rs/examples/function_call_structured.rs
@@ -25,8 +25,7 @@ async fn get_weather(city: String) -> Result<String, Box<dyn std::error::Error +
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Sync + Send>> {
-    //let ollama = Ollama::default();
-    let ollama = Ollama::new("http://ryzen.local".to_string(), 11434);
+    let ollama = Ollama::default();
 
     let history = vec![];
     let tools = ollama_rs::tool_group![get_weather];

--- a/ollama-rs/examples/function_call_structured.rs
+++ b/ollama-rs/examples/function_call_structured.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use ollama_rs::{
     coordinator::Coordinator,
     generation::{

--- a/ollama-rs/src/coordinator.rs
+++ b/ollama-rs/src/coordinator.rs
@@ -108,6 +108,10 @@ impl<C: ChatHistory, T: ToolGroup> Coordinator<C, T> {
             let mut tools = vec![];
             T::tool_info(&mut tools);
 
+            // If no tools are specified, set the format on the request. Otherwise wait for the
+            // recursive call by checking that the last message in the history has a Tool role,
+            // before setting the format. Ollama otherwise won't call the tool if the format
+            // is set on the first request.
             if tools.len() == 0 {
                 request = request.format(format.clone());
             } else {


### PR DESCRIPTION
Adds a `format()` builder method to `Coordinator` to allow setting a structured output on a coordinator, and using them with tools.

An example `function_call_structured` was added

```
     Running `target/debug/examples/function_call_structured`
User: What's the weather in Nanaimo?
Get weather function called for Nanaimo
Assistant: {"city":"Nanaimo","temperature_units":"Celsius","temperature":8,"wind_units":"Km/h","wind":10,"pressure_units":"hPa","pressure":1002}
```