### PR TITLE
with feature modelfile: provide better access to modelfile contained information

### DIFF
--- a/ollama-rs/Cargo.toml
+++ b/ollama-rs/Cargo.toml
@@ -17,6 +17,7 @@ required-features = ["macros"]
 reqwest = { version = "0.12.12", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_with = { version = "3.12.0", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 tokio-stream = { version = "0.1.15", optional = true }
 url = "2"
@@ -31,6 +32,7 @@ thiserror = "2.0.11"
 calc = { version = "0.4.0", optional = true }
 html2md = { version = "0.2.15", optional = true }
 static_assertions = "1.1.0"
+modelfile = { version = "0.3.0", optional = true }
 
 ollama-rs-macros = { workspace = true, optional = true }
 
@@ -41,6 +43,7 @@ rustls = ["reqwest/rustls-tls"]
 headers = ["http"]
 tool-implementations = ["scraper", "text-splitter", "regex", "calc", "html2md"]
 macros = ["ollama-rs-macros"]
+modelfile = ["dep:modelfile", "dep:serde_with"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/ollama-rs/src/models.rs
+++ b/ollama-rs/src/models.rs
@@ -34,6 +34,9 @@ pub struct LocalModel {
 /// This struct contains various fields that describe a model's attributes,
 /// such as its license, file, parameters, and template.
 /// Some fields may be empty if the model does not have them.
+///
+/// By default the modelfile is a string, but if the `modelfile` feature is enabled,
+/// it will be a `Modelfile` struct. See the modelfile crate for more information.
 #[cfg_attr(feature = "modelfile", serde_with::serde_as)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {

--- a/ollama-rs/src/models.rs
+++ b/ollama-rs/src/models.rs
@@ -10,6 +10,12 @@ pub mod pull;
 pub mod push;
 pub mod show_info;
 
+#[cfg(feature = "modelfile")]
+use modelfile::modelfile::Modelfile;
+
+#[cfg(feature = "modelfile")]
+use serde_with;
+
 use serde::{Deserialize, Serialize};
 
 /// Represents a local model pulled from Ollama.
@@ -28,10 +34,15 @@ pub struct LocalModel {
 /// This struct contains various fields that describe a model's attributes,
 /// such as its license, file, parameters, and template.
 /// Some fields may be empty if the model does not have them.
+#[cfg_attr(feature = "modelfile", serde_with::serde_as)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelInfo {
     #[serde(default = "String::new")]
     pub license: String,
+    #[cfg(feature = "modelfile")]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub modelfile: Modelfile,
+    #[cfg(not(feature = "modelfile"))]
     #[serde(default = "String::new")]
     pub modelfile: String,
     #[serde(default = "String::new")]

--- a/ollama-rs/tests/show_model_info.rs
+++ b/ollama-rs/tests/show_model_info.rs
@@ -15,7 +15,7 @@ async fn test_show_model_info() {
 
 #[cfg(feature = "modelfile")]
 #[tokio::test]
-async fn test_show_model_info_from() {
+async fn test_model_info_modelfile_param_stop() {
     let ollama = ollama_rs::Ollama::default();
 
     let model_info = ollama

--- a/ollama-rs/tests/show_model_info.rs
+++ b/ollama-rs/tests/show_model_info.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "modelfile")]
+use modelfile::modelfile::{Instruction, Parameter};
+
 #[tokio::test]
 async fn test_show_model_info() {
     let ollama = ollama_rs::Ollama::default();
@@ -8,4 +11,26 @@ async fn test_show_model_info() {
         .unwrap();
 
     dbg!(model_info);
+}
+
+#[cfg(feature = "modelfile")]
+#[tokio::test]
+async fn test_show_model_info_from() {
+    let ollama = ollama_rs::Ollama::default();
+
+    let model_info = ollama
+        .show_model_info("llama2:latest".to_string())
+        .await
+        .unwrap();
+
+    let stop = model_info
+        .modelfile
+        .instructions()
+        .find_map(|i| match i {
+            Instruction::Parameter(Parameter::Stop(s)) => Some(s),
+            _ => None,
+        })
+        .unwrap();
+
+    assert_eq!(stop, "[INST]");
 }


### PR DESCRIPTION
Allow better access to modelinfo.modelfile info. `cargo add --features modelfile ollam-rs` and then. Example:

```rust
    let model_info = ollama
        .show_model_info("llama2:latest".to_string())
        .await
        .unwrap();

    let from = model_info
        .modelfile
        .instructions()
        .find_map(|i| match i {
            Instruction::From(s) => Some(s),
            _ => None,
        })
        .unwrap();

    eprintln!("model_info.modelfile.from: {from}");
```
Besides the modelfile crate also includes serde_with to allow fromstr (de)serialization. Included a few doc lines and the test:
```bash
cargo test --features modelfile test_model_info_modelfile_param_stop
```