### PR TITLE
Match Ollama's integer width for response token counters

### DIFF
--- a/ollama-rs/src/generation/chat/mod.rs
+++ b/ollama-rs/src/generation/chat/mod.rs
@@ -189,11 +189,11 @@ pub struct ChatMessageFinalResponseData {
     /// Time spent generating the response
     pub total_duration: u64,
     /// Number of tokens in the prompt
-    pub prompt_eval_count: u16,
+    pub prompt_eval_count: u64,
     /// Time spent in nanoseconds evaluating the prompt
     pub prompt_eval_duration: u64,
     /// Number of tokens the response
-    pub eval_count: u16,
+    pub eval_count: u64,
     /// Time in nanoseconds spent generating the response
     pub eval_duration: u64,
 }

--- a/ollama-rs/src/generation/completion/mod.rs
+++ b/ollama-rs/src/generation/completion/mod.rs
@@ -114,11 +114,11 @@ pub struct GenerationResponse {
     /// Time spent generating the response
     pub total_duration: Option<u64>,
     /// Number of tokens in the prompt
-    pub prompt_eval_count: Option<u16>,
+    pub prompt_eval_count: Option<u64>,
     /// Time spent in nanoseconds evaluating the prompt
     pub prompt_eval_duration: Option<u64>,
     /// Number of tokens in the response
-    pub eval_count: Option<u16>,
+    pub eval_count: Option<u64>,
     /// Time spent in nanoseconds generating the response
     pub eval_duration: Option<u64>,
 }


### PR DESCRIPTION
Currently, in ollama-rs, these fields  can only store numbers up to 2^16 which is insufficient compared to the large context size of models like qwen2.5-coder. Ollama uses Go's `int` type to store these counters, see https://github.com/ollama/ollama/blob/8294676150dde3dd3d316644b86e42b07204ff9c/api/types.go#L203C1-L203C71 . Go's `int` type can be up to 64bit width depending on the compilation target architecture. The client will never send these values towards the server, so the precise type doesn't matter as long as it can hold all values received from Ollama.