### PR TITLE
Implemented model_info field on ModelInfo struct

### DIFF
--- a/ollama-rs/src/models.rs
+++ b/ollama-rs/src/models.rs
@@ -52,6 +52,8 @@ pub struct ModelInfo {
     pub parameters: String,
     #[serde(default = "String::new")]
     pub template: String,
+    #[serde(default = "serde_json::Map::new")]
+    pub model_info: serde_json::Map<String, serde_json::Value>,
 }
 
 // Options for generation requests to Ollama.


### PR DESCRIPTION
Added the following on `ModelInfo` struct:
```rust
#[serde(default = "serde_json::Map::new")]
pub model_info: serde_json::Map<String, serde_json::Value>
```

Fixes https://github.com/pepperoni21/ollama-rs/issues/163