### PR TITLE
Fix: Ollama uses 'h' to specify hour durations.

### DIFF
--- a/ollama-rs/src/generation/parameters.rs
+++ b/ollama-rs/src/generation/parameters.rs
@@ -85,7 +85,7 @@ impl TimeUnit {
         match self {
             TimeUnit::Seconds => "s",
             TimeUnit::Minutes => "m",
-            TimeUnit::Hours => "hr",
+            TimeUnit::Hours => "h",
         }
     }
 }


### PR DESCRIPTION
Ollama 0.6.2 uses `h` to designate hours, not `hr`. I believe 0.5.x uses `h` as well.