### PR TITLE
Fix error formatting

### DIFF
--- a/ollama-rs/src/error.rs
+++ b/ollama-rs/src/error.rs
@@ -21,9 +21,9 @@ pub enum OllamaError {
     JsonError(#[from] serde_json::Error),
     #[error("Reqwest error")]
     ReqwestError(#[from] reqwest::Error),
-    #[error("Internal Ollama error")]
+    #[error("Internal Ollama error: {}", .0.message)]
     InternalError(InternalOllamaError),
-    #[error("Error in Ollama")]
+    #[error("{0}")]
     Other(String),
 }
 


### PR DESCRIPTION
Hey!

After trying this lib with my app it turns out error formatting was a bit strange. With `eyre` crate I was getting just `Error in Ollama` without the actual problem. This was because of debug and display formatting `thiserror` derives for you. It works good with `#[from]` and `#[source]` attributes, but for strings and other non-Error types is requires manual printing. I fixed this.

Also removed "Error in Ollama" description as it's pretty much the same as "Internal Ollama Error" and actually not always Ollama error. In my example it was proxy settings