### PR TITLE
Structured output: Support for runtime generated schema

### DIFF
--- a/ollama-rs/examples/structured_output_dynamic.rs
+++ b/ollama-rs/examples/structured_output_dynamic.rs
@@ -1,0 +1,57 @@
+use ollama_rs::{
+    generation::{
+        completion::request::GenerationRequest,
+        parameters::{FormatType, JsonSchema, JsonStructure},
+    },
+    models::ModelOptions,
+    Ollama,
+};
+use serde::Deserialize;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ollama = Ollama::default();
+    let model = "llama3.2:latest".to_string();
+    let prompt = "Tell me about the country north of the USA".to_string();
+    let structure = r#"
+    {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Output",
+        "type": "object",
+        "properties": {
+            "country": { "type": "string" },
+            "capital": { "type": "string" },
+            "languages": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "temperature": { "type": "string", "enum": ["Warm", "Cold"] }
+        },
+        "required": ["country", "capital", "languages", "temperature"]
+    }
+    "#;
+    let schema = serde_json::from_str(structure)?;
+
+    let format = FormatType::StructuredJson(JsonStructure::new_for_schema(schema));
+    dbg!(&format);
+    let res = ollama
+        .generate(
+            GenerationRequest::new(model, prompt)
+                .format(format)
+                .options(ModelOptions::default().temperature(0.0)),
+        )
+        .await?;
+
+    // Output {
+    //     country: "Canada",
+    //     capital: "Ottawa",
+    //     languages: [
+    //         "English",
+    //         "French",
+    //     ],
+    //     temperature: Cold,
+    // }
+    dbg!(&res.response);
+
+    Ok(())
+}

--- a/ollama-rs/examples/structured_output_dynamic.rs
+++ b/ollama-rs/examples/structured_output_dynamic.rs
@@ -1,12 +1,11 @@
 use ollama_rs::{
     generation::{
         completion::request::GenerationRequest,
-        parameters::{FormatType, JsonSchema, JsonStructure},
+        parameters::{FormatType, JsonStructure},
     },
     models::ModelOptions,
     Ollama,
 };
-use serde::Deserialize;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/ollama-rs/src/generation/parameters.rs
+++ b/ollama-rs/src/generation/parameters.rs
@@ -45,6 +45,10 @@ impl JsonStructure {
 
         Self { schema }
     }
+
+    pub fn new_for_schema(schema: RootSchema) -> Self {
+        Self { schema }
+    }
 }
 
 /// Used to control how long a model stays loaded in memory, by default models are unloaded after 5 minutes of inactivity


### PR DESCRIPTION
I have a use case where I need to construct a "Structured" schema during runtime instead of a compiled schema. I am exposing a constructor to accept a `RootSchema`.

See example for full details.

If you'd like I can remove the example prior to merge as it's just a slight variation of the other structured output example.