### PR TITLE
Set Content-Type header for JSON

### DIFF
--- a/ollama-rs/src/generation/chat/mod.rs
+++ b/ollama-rs/src/generation/chat/mod.rs
@@ -35,15 +35,12 @@ impl Ollama {
         request.stream = true;
 
         let url = format!("{}api/chat", self.url_str());
-        let serialized = serde_json::to_string(&request)
-            .map_err(|e| e.to_string())
-            .unwrap();
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(
@@ -123,13 +120,12 @@ impl Ollama {
         request.stream = false;
 
         let url = format!("{}api/chat", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(

--- a/ollama-rs/src/generation/completion/mod.rs
+++ b/ollama-rs/src/generation/completion/mod.rs
@@ -33,13 +33,12 @@ impl Ollama {
         request.stream = true;
 
         let url = format!("{}api/generate", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(
@@ -74,13 +73,12 @@ impl Ollama {
         request.stream = false;
 
         let url = format!("{}api/generate", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(

--- a/ollama-rs/src/generation/embeddings/mod.rs
+++ b/ollama-rs/src/generation/embeddings/mod.rs
@@ -15,13 +15,12 @@ impl Ollama {
         request: GenerateEmbeddingsRequest,
     ) -> crate::error::Result<GenerateEmbeddingsResponse> {
         let url = format!("{}api/embed", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(

--- a/ollama-rs/src/models/copy.rs
+++ b/ollama-rs/src/models/copy.rs
@@ -15,13 +15,12 @@ impl Ollama {
         };
 
         let url = format!("{}api/copy", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if res.status().is_success() {
             Ok(())

--- a/ollama-rs/src/models/create.rs
+++ b/ollama-rs/src/models/create.rs
@@ -26,13 +26,12 @@ impl Ollama {
         request.stream = true;
 
         let url = format!("{}api/create", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(res.text().await?));
@@ -68,13 +67,12 @@ impl Ollama {
         request: CreateModelRequest,
     ) -> crate::error::Result<CreateModelStatus> {
         let url = format!("{}api/create", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(res.text().await?));

--- a/ollama-rs/src/models/delete.rs
+++ b/ollama-rs/src/models/delete.rs
@@ -8,13 +8,12 @@ impl Ollama {
         let request = DeleteModelRequest { model_name };
 
         let url = format!("{}api/delete", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.delete(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if res.status().is_success() {
             Ok(())

--- a/ollama-rs/src/models/pull.rs
+++ b/ollama-rs/src/models/pull.rs
@@ -31,13 +31,12 @@ impl Ollama {
         };
 
         let url = format!("{}api/pull", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(res.text().await?));
@@ -78,13 +77,12 @@ impl Ollama {
         };
 
         let url = format!("{}api/pull", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(res.text().await?));

--- a/ollama-rs/src/models/push.rs
+++ b/ollama-rs/src/models/push.rs
@@ -31,13 +31,12 @@ impl Ollama {
         };
 
         let url = format!("{}api/push", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(res.text().await?));
@@ -83,13 +82,12 @@ impl Ollama {
         };
 
         let url = format!("{}api/push", self.url_str());
-        let serialized = serde_json::to_string(&request)?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder.json(&request).send().await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(res.text().await?));

--- a/ollama-rs/src/models/show_info.rs
+++ b/ollama-rs/src/models/show_info.rs
@@ -8,13 +8,15 @@ impl Ollama {
     /// Show details about a model including modelfile, template, parameters, license, and system prompt.
     pub async fn show_model_info(&self, model_name: String) -> crate::error::Result<ModelInfo> {
         let url = format!("{}api/show", self.url_str());
-        let serialized = serde_json::to_string(&ModelInfoRequest { model_name })?;
         let builder = self.reqwest_client.post(url);
 
         #[cfg(feature = "headers")]
         let builder = builder.headers(self.request_headers.clone());
 
-        let res = builder.body(serialized).send().await?;
+        let res = builder
+            .json(&ModelInfoRequest { model_name })
+            .send()
+            .await?;
 
         if !res.status().is_success() {
             return Err(OllamaError::Other(res.text().await?));


### PR DESCRIPTION
Having a Content-Type header can be useful for proper integration with other tools, e.g. [mitmproxy](https://mitmproxy.org/).

Note: if Content-Type is set in `request_headers` (with the `headers` feature activated), it will be kept as-is and used instead of JSON (this is done by `reqwest`).