### PR TITLE
feat: make ToolType and ToolFunctionInfo public

### DIFF
--- a/ollama-rs/src/coordinator.rs
+++ b/ollama-rs/src/coordinator.rs
@@ -22,7 +22,7 @@ pub struct Coordinator<C: ChatHistory> {
     options: ModelOptions,
     history: C,
     tool_infos: Vec<ToolInfo>,
-    tools: HashMap<&'static str, Box<dyn ToolHolder>>,
+    tools: HashMap<String, Box<dyn ToolHolder>>,
     debug: bool,
     format: Option<FormatType>,
 }
@@ -54,7 +54,7 @@ impl<C: ChatHistory> Coordinator<C> {
 
     pub fn add_tool<T: Tool + 'static>(mut self, tool: T) -> Self {
         self.tool_infos.push(ToolInfo::new::<_, T>());
-        self.tools.insert(T::name(), Box::new(tool));
+        self.tools.insert(T::name().to_string(), Box::new(tool));
         self
     }
 

--- a/ollama-rs/src/generation/tools/mod.rs
+++ b/ollama-rs/src/generation/tools/mod.rs
@@ -42,11 +42,11 @@ impl<T: Tool> ToolHolder for T {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ToolInfo {
     #[serde(rename = "type")]
-    tool_type: ToolType,
-    function: ToolFunctionInfo,
+    pub tool_type: ToolType,
+    pub function: ToolFunctionInfo,
 }
 
 impl ToolInfo {
@@ -60,24 +60,25 @@ impl ToolInfo {
         Self {
             tool_type: ToolType::Function,
             function: ToolFunctionInfo {
-                name: T::name(),
-                description: T::description(),
+                name: T::name().to_string(),
+                description: T::description().to_string(),
                 parameters,
             },
         }
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-enum ToolType {
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ToolType {
+    #[serde(rename_all(deserialize = "PascalCase"))]
     Function,
 }
 
-#[derive(Clone, Debug, Serialize)]
-struct ToolFunctionInfo {
-    name: &'static str,
-    description: &'static str,
-    parameters: RootSchema,
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ToolFunctionInfo {
+    pub name: String,
+    pub description: String,
+    pub parameters: RootSchema,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
The goal here is to allow for code to pass in tool metadata without having to define a static rust function as the handler. This required three changes:

1) some `&'static str` i think need to become `String`, or at least not `'static`. This PR makes them `String`.

2) ToolInfo and ToolFunctionInfo are crate-public/private and there is no public constructor of these. This PR makes these structs public, so that code can instantiate them directly.

3) Add `Deserialize` to ToolInfo and ToolFunctionInfo to allow separate specs to be deserialized directly into ollama-rs-compatible data structures -- these data structures appear to be essentially compatible with json schema, and so separate schemes for specifying tool schema can be deserialized directly into these ollama-rs structs.

It is possible that we don't need both 2 and 3. Perhaps with only 3, we don't need to expose ToolInfo and ToolFunctionInfo? Not sure, here. But if the goal is to support non-static definition of tools, perhaps doing both 2 and 3 is helpful towards that goal.