### PR TITLE
Add load_duration to GenerationResponse and ChatMessageFinalResponseData

### DIFF
--- a/ollama-rs/src/generation/chat/mod.rs
+++ b/ollama-rs/src/generation/chat/mod.rs
@@ -232,6 +232,8 @@ pub struct ChatMessageResponse {
 pub struct ChatMessageFinalResponseData {
     /// Time spent generating the response
     pub total_duration: u64,
+    /// Time spent in nanoseconds loading the model
+    pub load_duration: u64,
     /// Number of tokens in the prompt
     pub prompt_eval_count: u64,
     /// Time spent in nanoseconds evaluating the prompt

--- a/ollama-rs/src/generation/completion/mod.rs
+++ b/ollama-rs/src/generation/completion/mod.rs
@@ -113,6 +113,8 @@ pub struct GenerationResponse {
     pub context: Option<GenerationContext>,
     /// Time spent generating the response
     pub total_duration: Option<u64>,
+    /// Time spent in nanoseconds loading the model
+    pub load_duration: Option<u64>,
     /// Number of tokens in the prompt
     pub prompt_eval_count: Option<u64>,
     /// Time spent in nanoseconds evaluating the prompt


### PR DESCRIPTION
As documented here: https://github.com/ollama/ollama/blob/main/docs/api.md#response