### PR TITLE
Add capabilities to modelinfo

### DIFF
--- a/ollama-rs/src/models.rs
+++ b/ollama-rs/src/models.rs
@@ -54,6 +54,8 @@ pub struct ModelInfo {
     pub template: String,
     #[serde(default = "serde_json::Map::new")]
     pub model_info: serde_json::Map<String, serde_json::Value>,
+    #[serde(default = "Vec::new")]
+    pub capabilities: Vec<String>,
 }
 
 // Options for generation requests to Ollama.


### PR DESCRIPTION
This field identifies if a model has vision capabilities

```json
  "capabilities": [
    "completion",
    "vision"
  ],
```

from the docs

https://github.com/ollama/ollama/blob/a6ef73f4f26a22cc605516113625a404bd064250/docs/api.md?plain=1#L1266