### PR TITLE
Add raw parameter to GenerationRequest

### DIFF
--- a/ollama-rs/src/generation/completion/request.rs
+++ b/ollama-rs/src/generation/completion/request.rs
@@ -28,6 +28,8 @@ pub struct GenerationRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<GenerationContext>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<FormatType>,
@@ -46,6 +48,7 @@ impl<'a> GenerationRequest<'a> {
             options: None,
             system: None,
             template: None,
+            raw: None,
             context: None,
             format: None,
             keep_alive: None,
@@ -93,6 +96,12 @@ impl<'a> GenerationRequest<'a> {
     /// The full prompt or prompt template (overrides what is defined in the Modelfile)
     pub fn template(mut self, template: impl Into<Cow<'a, str>>) -> Self {
         self.template = Some(template.into());
+        self
+    }
+
+    /// If `true` no formatting will be applied to the prompt. You may choose to use the `raw` parameter if you are specifying a full templated prompt in your request to the API
+    pub fn raw(mut self, raw: bool) -> Self {
+        self.raw = Some(raw);
         self
     }
 


### PR DESCRIPTION
According to the [Ollama API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion), `/api/generate` has a parameter called `raw`, which can bypass the built-in templating mechanism.

I am developing a project that needs this feature, and noticed ollama-rs doesn’t have it. Therefore, I added this parameter to ollama-rs.

This change looks small, so I hope it won’t introduce new bugs. But I would appreciate it if anyone could help me perform more tests.