### PR TITLE
feat(macros): re-export schemars and serde

### DIFF
--- a/ollama-rs-macros/src/function.rs
+++ b/ollama-rs-macros/src/function.rs
@@ -59,6 +59,9 @@ pub fn function_impl(_attr: TokenStream, value: TokenStream) -> TokenStream {
             #[allow(unused_imports)]
             use super::*;
 
+            use ollama_rs::re_exports::schemars;
+            use ollama_rs::re_exports::serde;
+
             #function_params_struct_definition
         }
 
@@ -118,7 +121,8 @@ fn build_params_struct(input: &ItemFn, docs: &FunctionDocs) -> syn::Result<Param
     let tokens = quote_spanned!(span =>
         #[doc(hidden)]
         #[allow(non_camel_case_types, missing_docs)]
-        #[derive(::serde::Deserialize, ::schemars::JsonSchema)]
+        #[derive(serde::Deserialize, schemars::JsonSchema)]
+        #[serde(crate="ollama_rs::re_exports::serde")]
         pub struct #name {
             #(#fields)*
         }

--- a/ollama-rs/src/lib.rs
+++ b/ollama-rs/src/lib.rs
@@ -5,6 +5,12 @@ use url::Url;
 #[cfg(feature = "macros")]
 pub use ollama_rs_macros::function;
 
+#[cfg(feature = "macros")]
+pub mod re_exports {
+    pub use schemars;
+    pub use serde;
+}
+
 pub mod coordinator;
 pub mod error;
 pub mod generation;


### PR DESCRIPTION
Currently, the developer using the macro feature MUST use `serde` and `schemars`. With this fix, they are re-exported by `ollama-rs` instead. 