### PR TITLE
Rework url, so it always has a Host part

### DIFF
--- a/ollama-rs/src/headers.rs
+++ b/ollama-rs/src/headers.rs
@@ -1,4 +1,6 @@
-use crate::{IntoUrl, Ollama};
+use std::fmt::Debug;
+
+use crate::{HostUrl, Ollama};
 
 pub use http::header::*;
 
@@ -18,7 +20,11 @@ impl Ollama {
     /// # Panics
     ///
     /// Panics if the host is not a valid URL or if the URL cannot have a port.
-    pub fn new_with_request_headers(host: impl IntoUrl, port: u16, headers: HeaderMap) -> Self {
+    pub fn new_with_request_headers<TUrl>(host: TUrl, port: u16, headers: HeaderMap) -> Self
+    where
+        TUrl: TryInto<HostUrl>,
+        TUrl::Error: Debug,
+    {
         let mut ollama = Self::new(host, port);
         ollama.set_headers(Some(headers));
 

--- a/ollama-rs/src/url.rs
+++ b/ollama-rs/src/url.rs
@@ -1,0 +1,89 @@
+use std::{fmt::Display, ops::Deref, str::FromStr};
+
+use ::url::Url;
+
+/// Url which is guaranteed to have a Host part
+#[derive(Clone, Debug)]
+pub struct HostUrl(::url::Url);
+
+impl HostUrl {
+    pub fn host(&self) -> ::url::Host<&str> {
+        self.0.host().expect("Checked during construction")
+    }
+    #[allow(clippy::result_unit_err)]
+    pub fn set_port(&mut self, value: Option<u16>) -> Result<(), ()> {
+        self.0.set_port(value)
+    }
+}
+
+impl Display for HostUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Deref for HostUrl {
+    type Target = ::url::Url;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromStr for HostUrl {
+    type Err = HostUrlError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.try_into()
+    }
+}
+
+impl TryFrom<Url> for HostUrl {
+    type Error = HostUrlError;
+
+    fn try_from(value: Url) -> Result<Self, Self::Error> {
+        if value.host().is_some() {
+            Ok(HostUrl(value))
+        } else {
+            Err(HostUrlError::MissingUrl(value))
+        }
+    }
+}
+
+impl TryFrom<&str> for HostUrl {
+    type Error = HostUrlError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse::<::url::Url>()?.try_into()
+    }
+}
+
+impl TryFrom<String> for HostUrl {
+    type Error = HostUrlError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.as_str().try_into()
+    }
+}
+
+impl TryFrom<&String> for HostUrl {
+    type Error = HostUrlError;
+
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        value.as_str().try_into()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HostUrlError {
+    #[error("{0}")]
+    Parse(::url::ParseError),
+    #[error("Missing url: {0}")]
+    MissingUrl(::url::Url),
+}
+
+impl From<::url::ParseError> for HostUrlError {
+    fn from(value: ::url::ParseError) -> Self {
+        HostUrlError::Parse(value)
+    }
+}


### PR DESCRIPTION
Use Newtype for Url which always makes sure it contains a host part, which is required to communicate with the ollama service