### PR TITLE
Relax `Tool::call` future bound to `Send`

### DIFF
--- a/ollama-rs/src/generation/tools/mod.rs
+++ b/ollama-rs/src/generation/tools/mod.rs
@@ -25,7 +25,7 @@ pub trait Tool: Send + Sync {
     fn call(
         &mut self,
         parameters: Self::Params,
-    ) -> impl Future<Output = Result<String>> + Send + Sync;
+    ) -> impl Future<Output = Result<String>> + Send;
 }
 
 pub trait Parameters: DeserializeOwned + JsonSchema {}
@@ -36,14 +36,14 @@ pub(crate) trait ToolHolder: Send + Sync {
     fn call(
         &mut self,
         parameters: Value,
-    ) -> Pin<Box<dyn Future<Output = Result<String>> + '_ + Send + Sync>>;
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + '_ + Send>>;
 }
 
 impl<T: Tool> ToolHolder for T {
     fn call(
         &mut self,
         parameters: Value,
-    ) -> Pin<Box<dyn Future<Output = Result<String>> + '_ + Send + Sync>> {
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + '_ + Send>> {
         Box::pin(async move {
             // Json returned from the model can sometimes be in different formats, see https://github.com/pepperoni21/ollama-rs/issues/210
             // This is a work-around for this issue.


### PR DESCRIPTION
Fixes #291.

- Drop `+ Sync` from the future returned by `Tool::call` (and `ToolHolder::call`); keep `+ Send`.
- The `Tool: Send + Sync` bound on the implementor is unchanged.
- Rationale: `Coordinator` awaits tool calls sequentially, so `Send` alone is sufficient. The previous `+ Sync` bound forced every `.await` inside a tool body to yield only `Sync` futures, ruling out common ecosystem types like `bollard::Docker::start_exec`, which returns `Pin<Box<dyn Stream<…> + Send>>` (not `Sync`).
- Non-breaking: relaxing an auto-trait bound on a return type is backwards-compatible — existing `Tool` impls continue to compile.
- No test added — this is a bound relaxation with no runtime behavior change, and the repo has no `trybuild` scaffolding for compile-only checks.