### PR TITLE
Add streamed tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ _Returns a `GenerateEmbeddingsResponse` struct containing the embeddings (a vect
 
 ```rust
 use ollama_rs::coordinator::Coordinator;
-use ollama_rs::generation::chat::{ChatMessage, ChatMessageRequest};
+use ollama_rs::generation::chat::ChatMessage;
 use ollama_rs::generation::tools::implementations::{DDGSearcher, Scraper, Calculator};
 use ollama_rs::models::ModelOptions;
 
@@ -287,6 +287,17 @@ async fn get_weather(city: String) -> Result<String, Box<dyn std::error::Error +
 To create a custom tool, define a function that returns a `Result<String, Box<dyn std::error::Error + Sync + Send>>` and annotate it with the `function` macro. This function will be automatically converted into a tool that can be used with the `Coordinator`, just like any other tool.
 
 Ensure that the doc comment above the function clearly describes the tool's purpose and its parameters. This information will be provided to the LLM to help it understand how to use the tool.
+
+When using streaming chat directly, attach tool schemas to the request:
+
+```rust
+use ollama_rs::generation::chat::request::ChatMessageRequest;
+
+let request = ChatMessageRequest::new(model, messages).add_tool(get_weather);
+let mut stream = ollama.send_chat_messages_stream(request).await.unwrap();
+```
+
+`send_chat_messages_stream` yields streamed `ChatMessageResponse` chunks. If a chunk contains `message.tool_calls`, run the requested tools and include their results in a follow-up request.
 
 For a more detailed example, see the [function call example](https://github.com/pepperoni21/ollama-rs/blob/0.3.4/ollama-rs/examples/function_call.rs).
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ This library was created following the [Ollama API](https://github.com/jmorganca
 - [Installation](#installation)
 - [Initialization](#initialization)
 - [Usage](#usage)
-  - [Completion Generation](#completion-generation)
-  - [Completion Generation (Streaming)](#completion-generation-streaming)
-  - [Completion Generation (With Options)](#completion-generation-with-options)
-  - [Chat Mode](#chat-mode)
-  - [List Local Models](#list-local-models)
-  - [Show Model Information](#show-model-information)
-  - [Create a Model](#create-a-model)
-  - [Create a Model (Streaming)](#create-a-model-streaming)
-  - [Copy a Model](#copy-a-model)
-  - [Delete a Model](#delete-a-model)
-  - [Generate Embeddings](#generate-embeddings)
-  - [Generate Embeddings (Batch)](#generate-embeddings-batch)
-  - [Make a Function Call](#make-a-function-call)
-  - [Create a custom tool](#create-a-custom-tool)
-  - [Completion Generation (With Thinking)](#completion-generation-with-thinking)
+    - [Completion Generation](#completion-generation)
+    - [Completion Generation (Streaming)](#completion-generation-streaming)
+    - [Completion Generation (With Options)](#completion-generation-with-options)
+    - [Chat Mode](#chat-mode)
+    - [List Local Models](#list-local-models)
+    - [Show Model Information](#show-model-information)
+    - [Create a Model](#create-a-model)
+    - [Create a Model (Streaming)](#create-a-model-streaming)
+    - [Copy a Model](#copy-a-model)
+    - [Delete a Model](#delete-a-model)
+    - [Generate Embeddings](#generate-embeddings)
+    - [Generate Embeddings (Batch)](#generate-embeddings-batch)
+    - [Make a Function Call](#make-a-function-call)
+    - [Create a custom tool](#create-a-custom-tool)
+    - [Completion Generation (With Thinking)](#completion-generation-with-thinking)
 
 ## Installation
 
@@ -41,7 +41,7 @@ If you absolutely want the latest version, you can use the `master` branch by ad
 ollama-rs = { git = "https://github.com/pepperoni21/ollama-rs.git", branch = "master" }
 ```
 
-*Note that the `master` branch may not be stable and may contain breaking changes.*
+_Note that the `master` branch may not be stable and may contain breaking changes._
 
 ## Initialization
 
@@ -288,12 +288,12 @@ To create a custom tool, define a function that returns a `Result<String, Box<dy
 
 Ensure that the doc comment above the function clearly describes the tool's purpose and its parameters. This information will be provided to the LLM to help it understand how to use the tool.
 
-When using streaming chat directly, attach tool schemas to the request:
+When using streaming chat directly, you may also attach tool schemas to the request:
 
 ```rust
 use ollama_rs::generation::chat::request::ChatMessageRequest;
 
-let request = ChatMessageRequest::new(model, messages).add_tool(get_weather);
+let request = ChatMessageRequest::new("lfm2.5:8b".to_owned(), Vec::new()).add_tool(get_weather);
 let mut stream = ollama.send_chat_messages_stream(request).await.unwrap();
 ```
 

--- a/ollama-rs/src/coordinator.rs
+++ b/ollama-rs/src/coordinator.rs
@@ -57,7 +57,7 @@ impl<C: ChatHistory> Coordinator<C> {
     }
 
     pub fn add_tool<T: Tool + 'static>(mut self, tool: T) -> Self {
-        self.tool_infos.push(ToolInfo::new::<_, T>());
+        self.tool_infos.push(ToolInfo::from_tool::<T>());
         self.tools.insert(T::name().to_string(), Box::new(tool));
         self
     }

--- a/ollama-rs/src/coordinator.rs
+++ b/ollama-rs/src/coordinator.rs
@@ -57,7 +57,7 @@ impl<C: ChatHistory> Coordinator<C> {
     }
 
     pub fn add_tool<T: Tool + 'static>(mut self, tool: T) -> Self {
-        self.tool_infos.push(ToolInfo::from_tool::<T>());
+        self.tool_infos.push(ToolInfo::new::<_, T>());
         self.tools.insert(T::name().to_string(), Box::new(tool));
         self
     }

--- a/ollama-rs/src/generation/chat/mod.rs
+++ b/ollama-rs/src/generation/chat/mod.rs
@@ -178,7 +178,7 @@ impl Ollama {
 
                 if item.done {
                     item.message.content = result.clone();
-                    history.lock().unwrap().push(ChatMessage::assistant(result.clone()));
+                    history.lock().unwrap().push(item.message.clone());
                     result.clear();
                 }
 
@@ -310,4 +310,90 @@ pub enum MessageRole {
     System,
     #[serde(rename = "tool")]
     Tool,
+}
+
+#[cfg(all(test, feature = "stream"))]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio_stream::StreamExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn streamed_history_preserves_final_message_tool_calls() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept request");
+
+            let mut request = Vec::new();
+            let mut buffer = [0; 1024];
+            loop {
+                let read = socket.read(&mut buffer).await.expect("read request");
+                if read == 0 {
+                    break;
+                }
+
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+
+            let body = concat!(
+                r#"{"model":"test","created_at":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":"hello "},"done":false}"#,
+                "\n",
+                r#"{"model":"test","created_at":"2026-01-01T00:00:00Z","message":{"role":"assistant","content":"world","tool_calls":[{"function":{"name":"test_tool","arguments":{"city":"Paris"}}}]},"done":true}"#,
+                "\n",
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/x-ndjson\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+
+            socket
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+
+        let ollama = Ollama::try_new(format!("http://{addr}")).expect("build test client");
+        let history = Arc::new(Mutex::new(Vec::new()));
+        let request = ChatMessageRequest::new(
+            "test".to_string(),
+            vec![ChatMessage::user("use the tool".to_string())],
+        );
+
+        let mut stream = ollama
+            .send_chat_messages_with_history_stream(history.clone(), request)
+            .await
+            .expect("stream starts");
+
+        let mut final_chunk = None;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.expect("chunk ok");
+            if chunk.done {
+                final_chunk = Some(chunk);
+                break;
+            }
+        }
+
+        server.await.expect("server completes");
+
+        let final_chunk = final_chunk.expect("received done chunk");
+        assert_eq!(final_chunk.message.content, "hello world");
+        assert_eq!(final_chunk.message.tool_calls.len(), 1);
+
+        let history = history.lock().expect("history lock");
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[1].content, "hello world");
+        assert_eq!(history[1].tool_calls.len(), 1);
+        assert_eq!(history[1].tool_calls[0].function.name, "test_tool");
+    }
 }

--- a/ollama-rs/src/generation/chat/request.rs
+++ b/ollama-rs/src/generation/chat/request.rs
@@ -93,7 +93,7 @@ impl ChatMessageRequest {
     /// callers are responsible for consuming streamed tool calls and appending
     /// tool results to the next request.
     pub fn add_tool<T: Tool>(mut self, _tool: T) -> Self {
-        self.tools.push(ToolInfo::from_tool::<T>());
+        self.tools.push(ToolInfo::new::<_, T>());
         self
     }
 

--- a/ollama-rs/src/generation/chat/request.rs
+++ b/ollama-rs/src/generation/chat/request.rs
@@ -88,7 +88,8 @@ impl ChatMessageRequest {
     /// Add a tool definition that is available to the LLM.
     ///
     /// This consumes the tool value only to identify its schema. The request does
-    /// not retain or execute the tool. When using `Ollama::send_chat_messages_stream`,
+    /// not retain or execute the tool. When using
+    /// [`Ollama::send_chat_messages_stream`](crate::Ollama::send_chat_messages_stream),
     /// callers are responsible for consuming streamed tool calls and appending
     /// tool results to the next request.
     pub fn add_tool<T: Tool>(mut self, _tool: T) -> Self {

--- a/ollama-rs/src/generation/chat/request.rs
+++ b/ollama-rs/src/generation/chat/request.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     generation::{
         parameters::{FormatType, KeepAlive, ThinkType},
-        tools::ToolInfo,
+        tools::{Tool, ToolInfo},
     },
     models::ModelOptions,
 };
@@ -26,7 +26,7 @@ pub struct ChatMessageRequest {
     pub format: Option<FormatType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_alive: Option<KeepAlive>,
-    /// Must be false if tools are provided
+    /// Set by the chat send methods before the request is sent.
     #[serde(default)]
     pub(crate) stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -85,6 +85,17 @@ impl ChatMessageRequest {
         self
     }
 
+    /// Add a tool definition that is available to the LLM.
+    ///
+    /// This consumes the tool value only to identify its schema. The request does
+    /// not retain or execute the tool. When using `Ollama::send_chat_messages_stream`,
+    /// callers are responsible for consuming streamed tool calls and appending
+    /// tool results to the next request.
+    pub fn add_tool<T: Tool>(mut self, _tool: T) -> Self {
+        self.tools.push(ToolInfo::from_tool::<T>());
+        self
+    }
+
     /// Used to control whether thinking/reasoning models will think before responding
     pub fn think(mut self, think: impl Into<ThinkType>) -> Self {
         self.think = Some(think.into());
@@ -108,6 +119,7 @@ impl ChatMessageRequest {
 mod tests {
     use super::*;
     use crate::generation::parameters::{FormatType, JsonSchema, JsonStructure};
+    use serde::Deserialize;
     use serde_json::Value;
 
     #[allow(dead_code)]
@@ -155,5 +167,74 @@ mod tests {
             value.get("stream").expect("stream field present"),
             &Value::Bool(false)
         );
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug, Deserialize, JsonSchema)]
+    struct TestToolParams {
+        city: String,
+    }
+
+    struct TestTool;
+
+    impl Tool for TestTool {
+        type Params = TestToolParams;
+
+        fn name() -> &'static str {
+            "test_weather"
+        }
+
+        fn description() -> &'static str {
+            "Gets test weather"
+        }
+
+        async fn call(
+            &mut self,
+            _parameters: Self::Params,
+        ) -> crate::generation::tools::Result<String> {
+            Ok("sunny".to_string())
+        }
+    }
+
+    #[test]
+    fn add_tool_serializes_tool_schema_for_streaming_request() {
+        let mut request = ChatMessageRequest::new(
+            "model".to_string(),
+            vec![ChatMessage::user("hello".to_string())],
+        )
+        .add_tool(TestTool);
+
+        request.stream = true;
+
+        let value = serde_json::to_value(&request).expect("serialize request");
+
+        assert_eq!(
+            value.get("stream").expect("stream field present"),
+            &Value::Bool(true)
+        );
+
+        let tools = value
+            .get("tools")
+            .expect("tools field present")
+            .as_array()
+            .expect("tools serialized as array");
+
+        assert_eq!(tools.len(), 1);
+
+        let function = tools[0]
+            .get("function")
+            .expect("function field present")
+            .as_object()
+            .expect("function serialized as object");
+
+        assert_eq!(
+            function.get("name").expect("name present"),
+            &Value::String("test_weather".to_string())
+        );
+        assert_eq!(
+            function.get("description").expect("description present"),
+            &Value::String("Gets test weather".to_string())
+        );
+        assert!(function.contains_key("parameters"));
     }
 }

--- a/ollama-rs/src/generation/tools/mod.rs
+++ b/ollama-rs/src/generation/tools/mod.rs
@@ -70,7 +70,7 @@ pub struct ToolInfo {
 impl ToolInfo {
     /// Builds the JSON schema information Ollama needs to make a [`Tool`]
     /// available to the model.
-    pub fn from_tool<T: Tool>() -> Self {
+    pub fn new<P: Parameters, T: Tool<Params = P>>() -> Self {
         let mut settings = SchemaSettings::draft07();
         settings.inline_subschemas = true;
         let generator = settings.into_generator();
@@ -85,10 +85,6 @@ impl ToolInfo {
                 parameters,
             },
         }
-    }
-
-    pub(crate) fn new<P: Parameters, T: Tool<Params = P>>() -> Self {
-        Self::from_tool::<T>()
     }
 }
 

--- a/ollama-rs/src/generation/tools/mod.rs
+++ b/ollama-rs/src/generation/tools/mod.rs
@@ -86,6 +86,10 @@ impl ToolInfo {
             },
         }
     }
+
+    pub(crate) fn new<P: Parameters, T: Tool<Params = P>>() -> Self {
+        Self::from_tool::<T>()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/ollama-rs/src/generation/tools/mod.rs
+++ b/ollama-rs/src/generation/tools/mod.rs
@@ -68,12 +68,14 @@ pub struct ToolInfo {
 }
 
 impl ToolInfo {
-    pub(crate) fn new<P: Parameters, T: Tool<Params = P>>() -> Self {
+    /// Builds the JSON schema information Ollama needs to make a [`Tool`]
+    /// available to the model.
+    pub fn from_tool<T: Tool>() -> Self {
         let mut settings = SchemaSettings::draft07();
         settings.inline_subschemas = true;
         let generator = settings.into_generator();
 
-        let parameters = generator.into_root_schema_for::<P>();
+        let parameters = generator.into_root_schema_for::<T::Params>();
 
         Self {
             tool_type: ToolType::Function,

--- a/ollama-rs/tests/chat_history_management.rs
+++ b/ollama-rs/tests/chat_history_management.rs
@@ -9,13 +9,12 @@ async fn test_chat_history_accumulated() {
 
     let mut history = vec![];
 
-    let model = std::env::var("OLLAMA_RS_TEST_MODEL").unwrap_or("gemma3:4b-cloud".to_owned());
+    let model = std::env::var("OLLAMA_RS_TEST_MODEL").unwrap_or_else(|_| "llama3.2:1b".to_owned());
 
     assert!(ollama
         .send_chat_messages_with_history(
             &mut history,
             ChatMessageRequest::new(
-                // FIXME: eugh
                 model.clone(),
                 vec![ChatMessage::new(
                     MessageRole::User,

--- a/ollama-rs/tests/chat_history_management.rs
+++ b/ollama-rs/tests/chat_history_management.rs
@@ -9,11 +9,14 @@ async fn test_chat_history_accumulated() {
 
     let mut history = vec![];
 
+    let model = std::env::var("OLLAMA_RS_TEST_MODEL").unwrap_or("gemma3:4b-cloud".to_owned());
+
     assert!(ollama
         .send_chat_messages_with_history(
             &mut history,
             ChatMessageRequest::new(
-                "granite-code:3b".into(),
+                // FIXME: eugh
+                model.clone(),
                 vec![ChatMessage::new(
                     MessageRole::User,
                     "Why is the sky blue?".into(),
@@ -27,7 +30,7 @@ async fn test_chat_history_accumulated() {
         .send_chat_messages_with_history(
             &mut history,
             ChatMessageRequest::new(
-                "granite-code:3b".into(),
+                model,
                 vec![ChatMessage::new(
                     MessageRole::User,
                     "But, why is the sky blue?".into()


### PR DESCRIPTION
Fixes #194.

Ollama supports tool calls in streamed chat responses, but `ollama-rs` only had the `.add_tool(...)` path through `Coordinator`. This adds an additive request-level path so callers using `send_chat_messages_stream` can attach tool schemas directly and handle streamed `message.tool_calls` themselves.

Changes:
- add `ChatMessageRequest::add_tool(tool)` for direct chat requests
- preserve full final streamed assistant messages in history, including `tool_calls`
- document direct streaming tool usage in the README

This intentionally does not add automatic multi-round tool execution to `send_chat_messages_stream`! callers must still consume tool calls, run tools, append tool results, and send the follow-up request. This isn't an agent harness as far as I am aware (Is that what ollama wants their API to end up being? They keep adding features related to such things. IDK)

Validation:
In addition to the usual cargo stuff, I also ran a live test and confirmed the streamed response ended with a valid tool call. Thought streaming tokens also works (I tested with qwen3.5:4b running on another machine on the LAN).

I did not refactor away the abhorrent `Arc<Mutex<T>>` slop yet, but fully intend to in a future PR.